### PR TITLE
fix(lint): remove 'useless_vec' lint error from test (#638).

### DIFF
--- a/crates/syster-base/src/syntax/sysml/ast/tests/tests_types_usage.rs
+++ b/crates/syster-base/src/syntax/sysml/ast/tests/tests_types_usage.rs
@@ -779,7 +779,7 @@ fn test_usage_counting_anonymous_usages() {
 
 #[test]
 fn test_usage_counting_all_kinds() {
-    let kinds = vec![
+    let kinds = [
         UsageKind::Part,
         UsageKind::Port,
         UsageKind::Action,

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -54,6 +54,13 @@ We follow strict TDD practices:
 
 5. **Refactor while keeping tests green**
 
+6. **Verify all guidelines pass **
+   ```bash
+   make run-guidelines
+   ```
+
+cargo test test_concern_def_parsing
+
 ### 2. Incremental Development - STRICT LIMITS
 
 - **One function at a time:** Complete the full TDD cycle for one function before moving to the next


### PR DESCRIPTION
 ## Description
Trivial update to address local lint error, updated contribution guidance to include 'make run-guidelines'

## Changes
    * Remove unused 'vec!' from test.
    * Added 'make run-guidelines' step to CONTRIBUTING.md (was noted in overall readme).

## Testing
- [N/A ] Added unit tests
- [N/A] Added integration tests
- [Y] Existing tests pass
- ran: ```make run-guidelines```, all passed

## Documentation
- [N/A ] Updated doc comments
- [N/A] Updated ARCHITECTURE.md if needed
- [No ] Updated README.md if needed
- [Y] Updated CONTRIBUTION.md if needed

## Related Issues
Closes #638