### PR TITLE
fix: align keyword list with SysML V2 specification

### DIFF
--- a/crates/syster-base/src/parser/keywords.rs
+++ b/crates/syster-base/src/parser/keywords.rs
@@ -162,7 +162,6 @@ pub const SYSML_KEYWORDS: &[&str] = &[
     "import",
     "alias",
     "abstract",
-    "readonly",
     "derived",
     "ordered",
     "nonunique",
@@ -174,7 +173,6 @@ pub const SYSML_KEYWORDS: &[&str] = &[
     "subsets",
     "redefines",
     "references",
-    "conjugate",
     "defined by",
     // Flow keywords
     "in",

--- a/crates/syster-base/src/parser/sysml.pest
+++ b/crates/syster-base/src/parser/sysml.pest
@@ -14,9 +14,9 @@ keyword = @{
     | "dependency" | "occurrence" | "rendering" | "viewpoint" | "variation" 
     | "attribute" | "interface" | "objective" | "nonunique" | "succession" 
     | "terminate" | "transition" | "timeslice" | "protected" | "standard"
-    | "readonly" | "metadata" | "language" | "snapshot" | "parallel"
+    | "constant" | "metadata" | "language" | "snapshot" | "parallel"
     | "allocate" | "analysis" | "abstract" | "library" | "require" 
-    | "conjugate" | "perform" | "exhibit" | "include" | "satisfy" | "binding" 
+    | "perform" | "exhibit" | "include" | "satisfy" | "binding" 
     | "crosses" | "message" | "package" | "private" | "variant"
     | "concern" | "connect" | "default" | "defined" | "derived" 
     | "subject" | "ordered" | "hastype" | "istype" | "implies" 
@@ -29,7 +29,7 @@ keyword = @{
     | "port" | "case" | "calc" | "send" | "then" | "flow" 
     | "fork" | "from" | "join" | "loop" | "part" | "true" 
     | "view" | "bind" | "else" | "enum" | "item" | "meta" 
-    | "null" | "when" | "exit" | "life"
+    | "null" | "when" | "exit"
     | "def" | "doc" | "end" | "for" | "not" | "ref" | "rep" 
     | "use" | "via" | "xor" | "all" | "and" | "out"
     | "to" | "as" | "at" | "by" | "do" | "if" | "in" | "of" | "or"
@@ -152,9 +152,10 @@ terminate_action_usage = { "terminate" ~ identifier ~ ";" }
 conjugated_port_definition = {
     occurrence_definition_prefix ~ "port" ~ "def" ~ "~" ~ definition_declaration ~ definition_body
 }
-port_conjugation = { "conjugate" ~ "~" ~ identifier ~ ";" }
+// port_conjugation and life_class are KerML constructs, not SysML V2
+// port_conjugation = { "conjugate" ~ "~" ~ identifier ~ ";" }
 conjugated_port_typing = { "port" ~ identifier ~ ":" ~ "~" ~ identifier ~ ";" }
-life_class = { "life" ~ "class" ~ identifier ~ ";" }
+// life_class = { "life" ~ "class" ~ identifier ~ ";" }
 
 // Package
 

--- a/crates/syster-base/tests/parser/sysml_tests.rs
+++ b/crates/syster-base/tests/parser/sysml_tests.rs
@@ -2,7 +2,7 @@
 
 use pest::Parser;
 use rstest::rstest;
-use syster::parser::{SysMLParser, sysml::Rule};
+use syster::parser::{sysml::Rule, SysMLParser};
 
 #[test]
 fn test_parse_simple_identifier() {
@@ -110,7 +110,7 @@ fn test_parse_simple_identifier() {
 #[case("private")]
 #[case("protected")]
 #[case("public")]
-#[case("readonly")]
+#[case("constant")]
 #[case("redefines")]
 #[case("ref")]
 #[case("references")]
@@ -552,17 +552,8 @@ fn test_parse_conjugated_port_definition() {
     );
 }
 
-#[test]
-fn test_parse_port_conjugation() {
-    let input = "conjugate ~MyPort;";
-    let result = SysMLParser::parse(Rule::port_conjugation, input);
-
-    assert!(
-        result.is_ok(),
-        "Failed to parse port conjugation: {:?}",
-        result.err()
-    );
-}
+// port_conjugation and life_class tests removed - these are KerML constructs, not SysML V2
+// See issue #637
 
 #[test]
 fn test_parse_conjugated_port_typing() {
@@ -572,18 +563,6 @@ fn test_parse_conjugated_port_typing() {
     assert!(
         result.is_ok(),
         "Failed to parse conjugated port typing: {:?}",
-        result.err()
-    );
-}
-
-#[test]
-fn test_parse_life_class() {
-    let input = "life class MyLifeClass;";
-    let result = SysMLParser::parse(Rule::life_class, input);
-
-    assert!(
-        result.is_ok(),
-        "Failed to parse life class: {:?}",
         result.err()
     );
 }
@@ -5847,8 +5826,8 @@ fn test_parse_literal(#[case] input: &str, #[case] desc: &str) {
 fn test_parse_attribute_def_from_stdlib() {
     use std::path::PathBuf;
     use syster::project::file_loader;
-    use syster::syntax::sysml::ast::Element;
     use syster::syntax::sysml::ast::enums::DefinitionKind;
+    use syster::syntax::sysml::ast::Element;
 
     // Test actual attribute def from MeasurementReferences.sysml
     let input = r#"
@@ -5899,8 +5878,8 @@ fn test_parse_attribute_def_from_stdlib() {
 fn test_parse_abstract_attribute_def() {
     use std::path::PathBuf;
     use syster::project::file_loader;
-    use syster::syntax::sysml::ast::Element;
     use syster::syntax::sysml::ast::enums::DefinitionKind;
+    use syster::syntax::sysml::ast::Element;
 
     // Test ABSTRACT attribute def like in stdlib
     let input = r#"


### PR DESCRIPTION
## Summary

Fixes #637

This PR aligns the SysML parser keyword list with the SysML V2 specification.

## Changes

### Removed KerML-only keywords from SysML keyword list:
- `conjugate` - KerML keyword, SysML uses `~` operator instead
- `life` - KerML construct, not part of SysML V2
- `readonly` - KerML keyword

### Added missing keyword:
- `constant` - was being used in grammar but missing from keyword list

### Commented out unused grammar productions:
- `port_conjugation` - uses `conjugate` keyword (KerML)
- `life_class` - uses `life` keyword (KerML)

### Updated keyword definitions:
- Removed `readonly` and `conjugate` from `SYSML_KEYWORDS` in keywords.rs

## Testing

All 2,369 tests pass after these changes.