### PR TITLE
refactor: separate SymbolTable (data) from Resolver (algorithms)

### DIFF
--- a/crates/syster-base/src/semantic/adapters/kerml/inlay_hints.rs
+++ b/crates/syster-base/src/semantic/adapters/kerml/inlay_hints.rs
@@ -3,6 +3,7 @@
 //! Provides inline annotations for types, parameter names, and other contextual information.
 
 use crate::core::Position;
+use crate::semantic::resolver::Resolver;
 use crate::semantic::symbol_table::SymbolTable;
 use crate::semantic::types::{InlayHint, InlayHintKind};
 use crate::syntax::kerml::ast::{Element, Feature, FeatureMember, KerMLFile};
@@ -64,7 +65,8 @@ fn collect_feature_hints(
 
         if !has_typing && feature.span.is_some() {
             // Try to infer type from symbol table
-            if let Some(symbol) = symbol_table.lookup(name) {
+            let resolver = Resolver::new(symbol_table);
+            if let Some(symbol) = resolver.resolve(name) {
                 let type_name = match symbol {
                     crate::semantic::symbol_table::Symbol::Feature { feature_type, .. } => {
                         feature_type.as_ref()

--- a/crates/syster-base/src/semantic/adapters/kerml/tests/tests_visitor.rs
+++ b/crates/syster-base/src/semantic/adapters/kerml/tests/tests_visitor.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::unwrap_used)]
+use crate::semantic::resolver::Resolver;
 
 use crate::parser::{KerMLParser, kerml::Rule};
 use crate::semantic::RelationshipGraph;
@@ -19,7 +20,7 @@ fn test_kerml_visitor_creates_package_symbol() {
     let mut adapter = KermlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    assert!(symbol_table.lookup("MyPackage").is_some());
+    assert!(Resolver::new(&symbol_table).resolve("MyPackage").is_some());
 }
 
 #[test]
@@ -33,7 +34,8 @@ fn test_kerml_visitor_creates_classifier_symbol() {
     let mut adapter = KermlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let symbol = symbol_table.lookup("Vehicle").unwrap();
+    let _resolver = Resolver::new(&symbol_table);
+    let symbol = _resolver.resolve("Vehicle").unwrap();
     match symbol {
         Symbol::Classifier { kind, .. } => assert_eq!(kind, "Classifier"),
         _ => panic!("Expected Classifier symbol"),
@@ -51,7 +53,8 @@ fn test_kerml_visitor_creates_datatype_symbol() {
     let mut adapter = KermlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let symbol = symbol_table.lookup("Temperature").unwrap();
+    let _resolver = Resolver::new(&symbol_table);
+    let symbol = _resolver.resolve("Temperature").unwrap();
     match symbol {
         Symbol::Definition { kind, .. } => assert_eq!(kind, "Datatype"),
         _ => panic!("Expected Definition symbol"),
@@ -69,7 +72,8 @@ fn test_kerml_visitor_creates_feature_symbol() {
     let mut adapter = KermlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let symbol = symbol_table.lookup("mass").unwrap();
+    let _resolver = Resolver::new(&symbol_table);
+    let symbol = _resolver.resolve("mass").unwrap();
     match symbol {
         Symbol::Feature { .. } => (),
         _ => panic!("Expected Feature symbol"),
@@ -91,7 +95,7 @@ fn test_kerml_visitor_handles_nested_elements() {
     let mut adapter = KermlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    assert!(symbol_table.lookup("OuterPackage").is_some());
+    assert!(Resolver::new(&symbol_table).resolve("OuterPackage").is_some());
 
     // Nested elements must be looked up via all_symbols since they're in a nested scope
     let all_symbols = symbol_table.all_symbols();
@@ -119,7 +123,8 @@ fn test_kerml_visitor_creates_function_symbol() {
     let mut adapter = KermlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let symbol = symbol_table.lookup("calculateArea").unwrap();
+    let _resolver = Resolver::new(&symbol_table);
+    let symbol = _resolver.resolve("calculateArea").unwrap();
     match symbol {
         Symbol::Definition { kind, .. } => assert_eq!(kind, "Function"),
         _ => panic!("Expected Function symbol"),
@@ -140,8 +145,8 @@ fn test_kerml_visitor_handles_specialization_relationships() {
     let mut adapter = KermlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    assert!(symbol_table.lookup("Vehicle").is_some());
-    assert!(symbol_table.lookup("Car").is_some());
+    assert!(Resolver::new(&symbol_table).resolve("Vehicle").is_some());
+    assert!(Resolver::new(&symbol_table).resolve("Car").is_some());
 
     // Verify the relationship graph has the specialization
     let relationships = graph.get_all_relationships("Car");
@@ -162,8 +167,8 @@ fn test_kerml_visitor_handles_feature_typing() {
     let mut adapter = KermlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    assert!(symbol_table.lookup("Real").is_some());
-    assert!(symbol_table.lookup("mass").is_some());
+    assert!(Resolver::new(&symbol_table).resolve("Real").is_some());
+    assert!(Resolver::new(&symbol_table).resolve("mass").is_some());
 
     // Verify the relationship graph has the typing relationship
     let relationships = graph.get_all_relationships("mass");
@@ -184,7 +189,8 @@ fn test_kerml_visitor_handles_abstract_classifiers() {
     let mut adapter = KermlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let symbol = symbol_table.lookup("Shape").unwrap();
+    let _resolver = Resolver::new(&symbol_table);
+    let symbol = _resolver.resolve("Shape").unwrap();
     match symbol {
         Symbol::Classifier {
             kind, is_abstract, ..
@@ -208,7 +214,8 @@ fn test_kerml_visitor_handles_readonly_features() {
     adapter.populate(&file).unwrap();
 
     // For now, just verify the symbol exists - readonly modifier tracking will be added later
-    let symbol = symbol_table.lookup("timestamp");
+    let _resolver = Resolver::new(&symbol_table);
+    let symbol = _resolver.resolve("timestamp");
     assert!(symbol.is_some(), "timestamp feature should exist");
 }
 
@@ -226,8 +233,8 @@ fn test_kerml_visitor_handles_redefinition() {
     let mut adapter = KermlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    assert!(symbol_table.lookup("baseFeature").is_some());
-    assert!(symbol_table.lookup("derivedFeature").is_some());
+    assert!(Resolver::new(&symbol_table).resolve("baseFeature").is_some());
+    assert!(Resolver::new(&symbol_table).resolve("derivedFeature").is_some());
 
     // Verify the relationship graph has the redefinition
     let relationships = graph.get_all_relationships("derivedFeature");
@@ -254,7 +261,7 @@ fn test_kerml_visitor_handles_imports() {
     // Should not error on imports
     let result = adapter.populate(&file);
     assert!(result.is_ok(), "Should handle imports without error");
-    assert!(symbol_table.lookup("MyPackage").is_some());
+    assert!(Resolver::new(&symbol_table).resolve("MyPackage").is_some());
 }
 
 #[test]
@@ -273,8 +280,8 @@ fn test_kerml_visitor_handles_multiple_packages() {
     adapter.populate(&file).unwrap();
     for (_name, _) in symbol_table.all_symbols() {}
 
-    assert!(symbol_table.lookup("Package1").is_some());
-    assert!(symbol_table.lookup("Package2").is_some());
+    assert!(Resolver::new(&symbol_table).resolve("Package1").is_some());
+    assert!(Resolver::new(&symbol_table).resolve("Package2").is_some());
 }
 
 #[test]
@@ -288,7 +295,7 @@ fn test_kerml_visitor_handles_empty_package() {
     let mut adapter = KermlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    assert!(symbol_table.lookup("EmptyPackage").is_some());
+    assert!(Resolver::new(&symbol_table).resolve("EmptyPackage").is_some());
 }
 
 #[test]

--- a/crates/syster-base/src/semantic/adapters/sysml/inlay_hints.rs
+++ b/crates/syster-base/src/semantic/adapters/sysml/inlay_hints.rs
@@ -3,6 +3,7 @@
 //! Provides inline annotations for types, parameter names, and other contextual information.
 
 use crate::core::Position;
+use crate::semantic::resolver::Resolver;
 use crate::semantic::symbol_table::SymbolTable;
 use crate::semantic::types::{InlayHint, InlayHintKind};
 use crate::syntax::sysml::ast::{
@@ -80,7 +81,8 @@ fn collect_usage_hints(
 
         if !has_typing && usage.span.is_some() {
             // Try to infer type from symbol table
-            if let Some(symbol) = symbol_table.lookup(name) {
+            let resolver = Resolver::new(symbol_table);
+            if let Some(symbol) = resolver.resolve(name) {
                 // For usage symbols, check usage_type field
                 let type_name = match symbol {
                     crate::semantic::symbol_table::Symbol::Usage { usage_type, .. } => {

--- a/crates/syster-base/src/semantic/adapters/sysml/tests/tests_visitor.rs
+++ b/crates/syster-base/src/semantic/adapters/sysml/tests/tests_visitor.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::unwrap_used)]
+use crate::semantic::resolver::Resolver;
 
 use crate::core::constants::*;
 use crate::parser::{SysMLParser, sysml::Rule};
@@ -20,7 +21,7 @@ fn test_visitor_creates_package_symbol() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    assert!(symbol_table.lookup("MyPackage").is_some());
+    assert!(Resolver::new(&symbol_table).resolve("MyPackage").is_some());
 }
 
 #[test]
@@ -34,7 +35,8 @@ fn test_visitor_creates_definition_symbol() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let symbol = symbol_table.lookup("Vehicle").unwrap();
+    let _resolver = Resolver::new(&symbol_table);
+    let symbol = _resolver.resolve("Vehicle").unwrap();
     match symbol {
         Symbol::Definition { kind, .. } => assert_eq!(kind, "Part"),
         _ => panic!("Expected Definition symbol"),
@@ -390,7 +392,8 @@ fn test_visitor_creates_usage_symbol() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let symbol = symbol_table.lookup("myCar").unwrap();
+    let _resolver = Resolver::new(&symbol_table);
+    let symbol = _resolver.resolve("myCar").unwrap();
     match symbol {
         Symbol::Usage { usage_type, .. } => {
             assert_eq!(usage_type.as_deref(), Some("Vehicle"));
@@ -441,7 +444,7 @@ fn test_visitor_handles_nested_usage() {
     adapter.populate(&file).unwrap();
 
     // Check that Car definition exists
-    assert!(symbol_table.lookup("Car").is_some());
+    assert!(Resolver::new(&symbol_table).resolve("Car").is_some());
 
     // Check that mass exists and has the correct qualified name
     let all_symbols = symbol_table.all_symbols();
@@ -506,9 +509,9 @@ fn test_multiple_symbols_in_same_scope() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    assert!(symbol_table.lookup("Car").is_some());
-    assert!(symbol_table.lookup("Truck").is_some());
-    assert!(symbol_table.lookup("Motorcycle").is_some());
+    assert!(Resolver::new(&symbol_table).resolve("Car").is_some());
+    assert!(Resolver::new(&symbol_table).resolve("Truck").is_some());
+    assert!(Resolver::new(&symbol_table).resolve("Motorcycle").is_some());
 }
 
 #[test]
@@ -528,7 +531,7 @@ fn test_deeply_nested_symbols() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
     // Check all three levels exist
-    assert!(symbol_table.lookup("Vehicle").is_some());
+    assert!(Resolver::new(&symbol_table).resolve("Vehicle").is_some());
 
     let all_symbols = symbol_table.all_symbols();
     let engine = all_symbols
@@ -571,19 +574,22 @@ fn test_different_definition_kinds() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let part_def = symbol_table.lookup("PartDef").unwrap();
+    let _resolver = Resolver::new(&symbol_table);
+    let part_def = _resolver.resolve("PartDef").unwrap();
     match part_def {
         Symbol::Definition { kind, .. } => assert_eq!(kind, "Part"),
         _ => panic!("Expected Definition symbol"),
     }
 
-    let action_def = symbol_table.lookup("ActionDef").unwrap();
+    let _resolver = Resolver::new(&symbol_table);
+    let action_def = _resolver.resolve("ActionDef").unwrap();
     match action_def {
         Symbol::Definition { kind, .. } => assert_eq!(kind, "Action"),
         _ => panic!("Expected Definition symbol"),
     }
 
-    let req_def = symbol_table.lookup("ReqDef").unwrap();
+    let _resolver = Resolver::new(&symbol_table);
+    let req_def = _resolver.resolve("ReqDef").unwrap();
     match req_def {
         Symbol::Definition { kind, .. } => assert_eq!(kind, "Requirement"),
         _ => panic!("Expected Definition symbol"),
@@ -651,7 +657,11 @@ fn test_nested_packages() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    assert!(symbol_table.lookup("OuterPackage").is_some());
+    assert!(
+        Resolver::new(&symbol_table)
+            .resolve("OuterPackage")
+            .is_some()
+    );
 
     let all_symbols = symbol_table.all_symbols();
     let inner = all_symbols
@@ -678,7 +688,8 @@ fn test_empty_definition() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let symbol = symbol_table.lookup("EmptyPart").unwrap();
+    let _resolver = Resolver::new(&symbol_table);
+    let symbol = _resolver.resolve("EmptyPart").unwrap();
     match symbol {
         Symbol::Definition { name, .. } => assert_eq!(name, "EmptyPart"),
         _ => panic!("Expected Definition symbol"),
@@ -696,7 +707,8 @@ fn test_usage_without_type() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let symbol = symbol_table.lookup("untyped").unwrap();
+    let _resolver = Resolver::new(&symbol_table);
+    let symbol = _resolver.resolve("untyped").unwrap();
     match symbol {
         Symbol::Usage { usage_type, .. } => {
             assert_eq!(
@@ -725,7 +737,8 @@ fn test_qualified_names_are_correct() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let vehicles = symbol_table.lookup("Vehicles").unwrap();
+    let _resolver = Resolver::new(&symbol_table);
+    let vehicles = _resolver.resolve("Vehicles").unwrap();
     match vehicles {
         Symbol::Package { qualified_name, .. } => {
             assert_eq!(qualified_name, "Vehicles");
@@ -775,9 +788,10 @@ fn test_multiple_usages_of_same_type() {
     adapter.populate(&file).unwrap();
 
     // All three should exist and have the same typing
+    let resolver = Resolver::new(&symbol_table);
     for name in ["car1", "car2", "car3"] {
-        let symbol = symbol_table
-            .lookup(name)
+        let symbol = resolver
+            .resolve(name)
             .unwrap_or_else(|| panic!("Should have '{name}' symbol"));
         match symbol {
             Symbol::Usage { usage_type, .. } => {
@@ -802,7 +816,7 @@ fn test_redefinition_relationship() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    assert!(symbol_table.lookup("SportsCar").is_some());
+    assert!(Resolver::new(&symbol_table).resolve("SportsCar").is_some());
 
     // Check if redefinition relationship is recorded
     let redefinitions = graph.get_one_to_many(REL_REDEFINITION, "SportsCar");
@@ -869,7 +883,8 @@ fn test_port_definition_and_usage() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let port_def = symbol_table.lookup("DataPort").unwrap();
+    let _resolver = Resolver::new(&symbol_table);
+    let port_def = _resolver.resolve("DataPort").unwrap();
     match port_def {
         Symbol::Definition { kind, .. } => {
             assert_eq!(kind, "Port");
@@ -912,7 +927,8 @@ fn test_action_with_parameters() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let action_def = symbol_table.lookup("ProcessData").unwrap();
+    let _resolver = Resolver::new(&symbol_table);
+    let action_def = _resolver.resolve("ProcessData").unwrap();
     match action_def {
         Symbol::Definition { kind, .. } => {
             assert_eq!(kind, "Action");
@@ -944,7 +960,8 @@ fn test_constraint_definition() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let constraint_def = symbol_table.lookup("SpeedLimit").unwrap();
+    let _resolver = Resolver::new(&symbol_table);
+    let constraint_def = _resolver.resolve("SpeedLimit").unwrap();
     match constraint_def {
         Symbol::Definition { kind, .. } => {
             assert_eq!(kind, "Constraint");
@@ -970,7 +987,8 @@ fn test_enumeration_definition() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let enum_def = symbol_table.lookup("Color").unwrap();
+    let _resolver = Resolver::new(&symbol_table);
+    let enum_def = _resolver.resolve("Color").unwrap();
     match enum_def {
         Symbol::Definition { kind, .. } => {
             assert_eq!(kind, "Enumeration");
@@ -1006,7 +1024,8 @@ fn test_state_definition() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let state_def = symbol_table.lookup("VehicleState").unwrap();
+    let _resolver = Resolver::new(&symbol_table);
+    let state_def = _resolver.resolve("VehicleState").unwrap();
     match state_def {
         Symbol::Definition { kind, .. } => {
             assert_eq!(kind, "State");
@@ -1026,7 +1045,8 @@ fn test_connection_definition() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let conn_def = symbol_table.lookup("DataFlow").unwrap();
+    let _resolver = Resolver::new(&symbol_table);
+    let conn_def = _resolver.resolve("DataFlow").unwrap();
     match conn_def {
         Symbol::Definition { kind, .. } => {
             assert_eq!(kind, "Connection");
@@ -1046,7 +1066,8 @@ fn test_interface_definition() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let intf_def = symbol_table.lookup("NetworkInterface").unwrap();
+    let _resolver = Resolver::new(&symbol_table);
+    let intf_def = _resolver.resolve("NetworkInterface").unwrap();
     match intf_def {
         Symbol::Definition { kind, .. } => {
             assert_eq!(kind, "Interface");
@@ -1066,7 +1087,8 @@ fn test_allocation_definition() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let alloc_def = symbol_table.lookup("ResourceAllocation").unwrap();
+    let _resolver = Resolver::new(&symbol_table);
+    let alloc_def = _resolver.resolve("ResourceAllocation").unwrap();
     match alloc_def {
         Symbol::Definition { kind, .. } => {
             assert_eq!(kind, "Allocation");
@@ -1096,10 +1118,10 @@ fn test_mixed_definitions_and_usages() {
     adapter.populate(&file).unwrap();
 
     // All definitions should exist
-    assert!(symbol_table.lookup("Engine").is_some());
-    assert!(symbol_table.lookup("Wheel").is_some());
-    assert!(symbol_table.lookup("Car").is_some());
-    assert!(symbol_table.lookup("myCar").is_some());
+    assert!(Resolver::new(&symbol_table).resolve("Engine").is_some());
+    assert!(Resolver::new(&symbol_table).resolve("Wheel").is_some());
+    assert!(Resolver::new(&symbol_table).resolve("Car").is_some());
+    assert!(Resolver::new(&symbol_table).resolve("myCar").is_some());
 
     // Check nested parts
     let all_symbols = symbol_table.all_symbols();
@@ -1122,7 +1144,8 @@ fn test_concern_and_requirement() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let concern = symbol_table.lookup("Safety").unwrap();
+    let _resolver = Resolver::new(&symbol_table);
+    let concern = _resolver.resolve("Safety").unwrap();
     match concern {
         Symbol::Definition { kind, .. } => {
             assert_eq!(kind, "UseCase"); // Concern maps to UseCase
@@ -1130,7 +1153,8 @@ fn test_concern_and_requirement() {
         _ => panic!("Expected Definition symbol"),
     }
 
-    let requirement = symbol_table.lookup("SafetyRequirement").unwrap();
+    let _resolver = Resolver::new(&symbol_table);
+    let requirement = _resolver.resolve("SafetyRequirement").unwrap();
     match requirement {
         Symbol::Definition { kind, .. } => {
             assert_eq!(kind, "Requirement");

--- a/crates/syster-base/src/semantic/adapters/sysml/visitors.rs
+++ b/crates/syster-base/src/semantic/adapters/sysml/visitors.rs
@@ -182,7 +182,7 @@ impl<'a> AstVisitor for SysmlAdapter<'a> {
         if is_anonymous
             && self
                 .symbol_table
-                .lookup_qualified(&qualified_name)
+                .find_by_qualified_name(&qualified_name)
                 .is_some()
         {
             return;
@@ -229,27 +229,12 @@ impl<'a> AstVisitor for SysmlAdapter<'a> {
                     subset.span,
                 );
             }
-            // Feature typing (:)
+            // Feature typing (:) - store raw target name, resolved post-population
             if let Some(ref target) = usage.relationships.typed_by {
-                // Resolve target to fully qualified name using symbol table lookup
-                let resolved_target = self
-                    .symbol_table
-                    .lookup(target)
-                    .or_else(|| self.symbol_table.lookup_qualified(target))
-                    .map(|s| s.qualified_name().to_string())
-                    .unwrap_or_else(|| {
-                        // If lookup fails and target contains ::, try prepending current namespace
-                        if target.contains("::") {
-                            format!("{}::{}", self.current_namespace.join("::"), target)
-                        } else {
-                            target.clone()
-                        }
-                    });
-
                 graph.add_one_to_one(
                     REL_TYPING,
                     &qualified_name,
-                    &resolved_target,
+                    target,
                     file,
                     usage.relationships.typed_by_span,
                 );

--- a/crates/syster-base/src/semantic/adapters/tests/tests_kerml_adapter.rs
+++ b/crates/syster-base/src/semantic/adapters/tests/tests_kerml_adapter.rs
@@ -4,6 +4,7 @@
 
 use super::super::kerml_adapter::KermlAdapter;
 use crate::semantic::graphs::RelationshipGraph;
+use crate::semantic::resolver::Resolver;
 use crate::semantic::symbol_table::{Symbol, SymbolTable};
 
 #[test]
@@ -52,7 +53,8 @@ fn test_new_adapter_can_access_symbol_table() {
     let adapter = KermlAdapter::new(&mut table);
 
     // Verify adapter can access the symbol table
-    let symbol = adapter.symbol_table.lookup("TestSymbol");
+    let _resolver = Resolver::new(&adapter.symbol_table);
+    let symbol = _resolver.resolve("TestSymbol");
     assert!(symbol.is_some());
 }
 
@@ -200,5 +202,9 @@ fn test_adapter_can_be_created_in_nested_scope() {
     let adapter = KermlAdapter::new(&mut table);
 
     // Adapter should still be able to access the symbol
-    assert!(adapter.symbol_table.lookup("InnerSymbol").is_some());
+    assert!(
+        Resolver::new(&adapter.symbol_table)
+            .resolve("InnerSymbol")
+            .is_some()
+    );
 }

--- a/crates/syster-base/src/semantic/adapters/tests/tests_sysml_adapter_sysmladapter.rs
+++ b/crates/syster-base/src/semantic/adapters/tests/tests_sysml_adapter_sysmladapter.rs
@@ -7,6 +7,7 @@
 //! - `visit_comment` - Tests comment handling
 
 use super::super::SysmlAdapter;
+use crate::semantic::resolver::Resolver;
 use crate::semantic::symbol_table::{Symbol, SymbolTable};
 use crate::syntax::sysml::ast::{Comment, Element, NamespaceDeclaration, SysMLFile};
 
@@ -32,7 +33,8 @@ fn test_visit_namespace_creates_package_symbol() {
     assert!(result.is_ok());
 
     // Verify the namespace was added as a Package symbol
-    let symbol = table.lookup("TestNamespace");
+    let _resolver = Resolver::new(&table);
+    let symbol = _resolver.resolve("TestNamespace");
     assert!(symbol.is_some());
 
     let Some(Symbol::Package {
@@ -67,7 +69,8 @@ fn test_visit_namespace_enters_namespace_scope() {
     // After populate, the adapter should have entered the namespace
     // We can't directly test current_namespace (it's private), but we can test
     // that the namespace affects scope by checking all_symbols
-    let symbol = table.lookup("MyNamespace");
+    let _resolver = Resolver::new(&table);
+    let symbol = _resolver.resolve("MyNamespace");
     assert!(symbol.is_some());
 }
 
@@ -89,7 +92,8 @@ fn test_visit_namespace_with_empty_name() {
     assert!(result.is_ok());
 
     // Even with empty name, should create a symbol
-    let symbol = table.lookup("");
+    let _resolver = Resolver::new(&table);
+    let symbol = _resolver.resolve("");
     assert!(symbol.is_some());
 }
 
@@ -110,7 +114,8 @@ fn test_visit_namespace_with_special_characters() {
     let result = adapter.populate(&file);
     assert!(result.is_ok());
 
-    let symbol = table.lookup("Name_With_Underscores123");
+    let _resolver = Resolver::new(&table);
+    let symbol = _resolver.resolve("Name_With_Underscores123");
     assert!(symbol.is_some());
 }
 
@@ -131,7 +136,8 @@ fn test_visit_namespace_stores_scope_id() {
     let result = adapter.populate(&file);
     assert!(result.is_ok());
 
-    let symbol = table.lookup("ScopedNamespace");
+    let _resolver = Resolver::new(&table);
+    let symbol = _resolver.resolve("ScopedNamespace");
     assert!(symbol.is_some());
 
     if let Some(Symbol::Package { scope_id, .. }) = symbol {
@@ -166,7 +172,8 @@ fn test_visit_namespace_with_span() {
     let result = adapter.populate(&file);
     assert!(result.is_ok());
 
-    let symbol = table.lookup("SpannedNamespace");
+    let _resolver = Resolver::new(&table);
+    let symbol = _resolver.resolve("SpannedNamespace");
     assert!(symbol.is_some());
 
     if let Some(Symbol::Package { span, .. }) = symbol {
@@ -223,7 +230,8 @@ fn test_visit_namespace_affects_subsequent_elements() {
     assert!(result.is_ok());
 
     // The namespace should exist
-    let ns_symbol = table.lookup("OuterNamespace");
+    let _resolver = Resolver::new(&table);
+    let ns_symbol = _resolver.resolve("OuterNamespace");
     assert!(ns_symbol.is_some());
 
     // The inner part should be qualified with the namespace
@@ -258,7 +266,8 @@ fn test_visit_namespace_multiple_namespaces_not_supported() {
     assert!(result.is_ok());
 
     // Only the first namespace should be in the symbol table
-    let symbol = table.lookup("FirstNamespace");
+    let _resolver = Resolver::new(&table);
+    let symbol = _resolver.resolve("FirstNamespace");
     assert!(symbol.is_some());
 }
 
@@ -424,8 +433,8 @@ fn test_visit_comment_between_definitions() {
     // Should have exactly 2 symbols (the definitions), not the comment
     let all_symbols = table.all_symbols();
     assert_eq!(all_symbols.len(), 2);
-    assert!(table.lookup("FirstPart").is_some());
-    assert!(table.lookup("SecondPart").is_some());
+    assert!(Resolver::new(&table).resolve("FirstPart").is_some());
+    assert!(Resolver::new(&table).resolve("SecondPart").is_some());
 }
 
 #[test]
@@ -568,7 +577,11 @@ fn test_namespace_with_comments() {
     // Should have only the namespace symbol, not the comment
     let all_symbols = table.all_symbols();
     assert_eq!(all_symbols.len(), 1);
-    assert!(table.lookup("DocumentedNamespace").is_some());
+    assert!(
+        Resolver::new(&table)
+            .resolve("DocumentedNamespace")
+            .is_some()
+    );
 }
 
 #[test]
@@ -594,7 +607,8 @@ fn test_comment_before_namespace_not_typical_but_handled() {
     assert!(result.is_ok());
 
     // The namespace should still be created
-    let symbol = table.lookup("LateNamespace");
+    let _resolver = Resolver::new(&table);
+    let symbol = _resolver.resolve("LateNamespace");
     assert!(symbol.is_some());
 
     // The comment should not create a symbol

--- a/crates/syster-base/src/semantic/analyzer/tests/tests_analyzer.rs
+++ b/crates/syster-base/src/semantic/analyzer/tests/tests_analyzer.rs
@@ -5,6 +5,7 @@ use super::super::*;
 use crate::semantic::RelationshipGraph;
 use crate::semantic::SemanticErrorKind;
 use crate::semantic::create_validator;
+use crate::semantic::resolver::Resolver;
 use crate::semantic::symbol_table::{Symbol, SymbolTable};
 use crate::semantic::types::{SemanticError, SemanticResult, SemanticRole};
 
@@ -263,7 +264,11 @@ fn test_analyzer_symbol_table_access() {
         )
         .unwrap();
 
-    assert!(analyzer.symbol_table().lookup("NewSymbol").is_some());
+    assert!(
+        Resolver::new(analyzer.symbol_table())
+            .resolve("NewSymbol")
+            .is_some()
+    );
 }
 
 #[test]
@@ -415,7 +420,7 @@ fn test_analyzer_immutable_access() {
 
     let analyzer = SemanticAnalyzer::with_symbol_table(table);
     let sym_table = analyzer.symbol_table();
-    assert!(sym_table.lookup("Test").is_some());
+    assert!(Resolver::new(&sym_table).resolve("Test").is_some());
 }
 
 #[test]
@@ -721,7 +726,8 @@ fn test_context_symbol_table_reference() {
 
     let graph = RelationshipGraph::new();
     let context = AnalysisContext::new(&table, &graph);
-    let lookup_result = context.symbol_table.lookup("Test");
+    let _resolver = Resolver::new(&context.symbol_table);
+    let lookup_result = _resolver.resolve("Test");
     assert!(lookup_result.is_some());
 }
 

--- a/crates/syster-base/src/semantic/processors/reference_collector.rs
+++ b/crates/syster-base/src/semantic/processors/reference_collector.rs
@@ -97,12 +97,8 @@ impl<'a> ReferenceCollector<'a> {
 
         // Apply references to symbols
         for (target_name, refs) in references_by_target {
-            let resolved_symbol = self
-                .symbol_table
-                .lookup_qualified(&target_name)
-                .or_else(|| self.symbol_table.lookup(&target_name));
-
-            if let Some(symbol) = resolved_symbol {
+            // Use find_by_qualified_name for data lookup during population
+            if let Some(symbol) = self.symbol_table.find_by_qualified_name(&target_name) {
                 let qualified_name = symbol.qualified_name().to_string();
                 self.symbol_table
                     .add_references_to_symbol(&qualified_name, refs);
@@ -126,13 +122,12 @@ impl<'a> ReferenceCollector<'a> {
                 }
 
                 // Try to resolve the imported path to a fully qualified name
-                let resolved = self
+                let target_qname = self
                     .symbol_table
-                    .lookup_qualified(&import.path)
-                    .or_else(|| self.symbol_table.lookup(&import.path))
+                    .find_by_qualified_name(&import.path)
                     .map(|s| s.qualified_name().to_string());
 
-                if let Some(target_qname) = resolved {
+                if let Some(target_qname) = target_qname {
                     // Create a reference for the import statement itself
                     if let (Some(span), Some(file)) = (import.span, import.file.clone()) {
                         // Add to the references HashMap for legacy symbol references

--- a/crates/syster-base/src/semantic/processors/tests/tests_processors.rs
+++ b/crates/syster-base/src/semantic/processors/tests/tests_processors.rs
@@ -4,6 +4,7 @@ use crate::core::constants::{
 };
 use crate::core::{Position, Span};
 use crate::semantic::graphs::RelationshipGraph;
+use crate::semantic::resolver::Resolver;
 use crate::semantic::symbol_table::{Symbol, SymbolTable};
 use crate::semantic::{NoOpValidator, RelationshipValidator};
 use crate::syntax::sysml::ast::{
@@ -100,7 +101,8 @@ fn test_typing_relationship_reference() {
     collector.collect();
 
     // Verify Vehicle has a reference from myCar
-    let vehicle = table.lookup("Vehicle").unwrap();
+    let _resolver = Resolver::new(&table);
+    let vehicle = _resolver.resolve("Vehicle").unwrap();
     assert_eq!(vehicle.references().len(), 1);
     assert_eq!(vehicle.references()[0].span.start.line, 5);
     assert_eq!(vehicle.references()[0].span.start.column, 0);
@@ -165,7 +167,8 @@ fn test_specialization_relationship_reference() {
     collector.collect();
 
     // Verify Vehicle has a reference from Car
-    let vehicle = table.lookup("Vehicle").unwrap();
+    let _resolver = Resolver::new(&table);
+    let vehicle = _resolver.resolve("Vehicle").unwrap();
     assert_eq!(vehicle.references().len(), 1);
     assert_eq!(vehicle.references()[0].span.start.line, 3);
 }
@@ -272,7 +275,8 @@ fn test_multiple_references_to_same_symbol() {
     collector.collect();
 
     // Verify Integer has references from all three features
-    let integer = table.lookup("Integer").unwrap();
+    let _resolver = Resolver::new(&table);
+    let integer = _resolver.resolve("Integer").unwrap();
     assert_eq!(integer.references().len(), 3);
 
     let lines: Vec<_> = integer
@@ -342,7 +346,8 @@ fn test_redefinition_reference() {
     collector.collect();
 
     // Verify Vehicle::mass has a reference from Car::mass
-    let base_mass = table.lookup("Vehicle::mass").unwrap();
+    let _resolver = Resolver::new(&table);
+    let base_mass = _resolver.resolve("Vehicle::mass").unwrap();
     assert_eq!(base_mass.references().len(), 1);
     assert_eq!(base_mass.references()[0].span.start.line, 6);
 }
@@ -404,7 +409,8 @@ fn test_subsetting_reference() {
     collector.collect();
 
     // Verify parts has a reference from engineParts
-    let parts = table.lookup("parts").unwrap();
+    let _resolver = Resolver::new(&table);
+    let parts = _resolver.resolve("parts").unwrap();
     assert_eq!(parts.references().len(), 1);
     assert_eq!(parts.references()[0].span.start.line, 4);
 }
@@ -470,7 +476,8 @@ fn test_reference_subsetting() {
     collector.collect();
 
     // Verify vehicle has a reference from car
-    let vehicle = table.lookup("vehicle").unwrap();
+    let _resolver = Resolver::new(&table);
+    let vehicle = _resolver.resolve("vehicle").unwrap();
     assert_eq!(vehicle.references().len(), 1);
     assert_eq!(vehicle.references()[0].span.start.line, 4);
 }
@@ -510,7 +517,8 @@ fn test_no_references() {
     collector.collect();
 
     // Verify no references collected
-    let standalone = table.lookup("StandaloneClass").unwrap();
+    let _resolver = Resolver::new(&table);
+    let standalone = _resolver.resolve("StandaloneClass").unwrap();
     assert_eq!(standalone.references().len(), 0);
 }
 
@@ -568,7 +576,8 @@ fn test_symbol_without_span() {
     collector.collect();
 
     // Verify no reference collected (source has no span)
-    let target = table.lookup("Target").unwrap();
+    let _resolver = Resolver::new(&table);
+    let target = _resolver.resolve("Target").unwrap();
     assert_eq!(target.references().len(), 0);
 }
 
@@ -656,7 +665,8 @@ fn test_mixed_relationships() {
     collector.collect();
 
     // Verify Base has references from both relationships
-    let base = table.lookup("Base").unwrap();
+    let _resolver = Resolver::new(&table);
+    let base = _resolver.resolve("Base").unwrap();
     assert_eq!(base.references().len(), 2);
 
     let lines: Vec<_> = base

--- a/crates/syster-base/src/semantic/resolver.rs
+++ b/crates/syster-base/src/semantic/resolver.rs
@@ -3,22 +3,13 @@ mod name_resolver;
 
 pub use name_resolver::Resolver;
 
-// Re-export import utility functions
+// Re-export import utility functions - these delegate to the syntax layer
 pub fn extract_imports(file: &crate::syntax::sysml::ast::SysMLFile) -> Vec<String> {
-    Resolver::extract_imports(file)
+    crate::syntax::file::extract_sysml_imports(file)
 }
 
 pub fn extract_kerml_imports(file: &crate::syntax::kerml::ast::KerMLFile) -> Vec<String> {
-    file.elements
-        .iter()
-        .filter_map(|element| {
-            if let crate::syntax::kerml::ast::Element::Import(import) = element {
-                Some(import.path.clone())
-            } else {
-                None
-            }
-        })
-        .collect()
+    crate::syntax::file::extract_kerml_imports(file)
 }
 
 pub fn parse_import_path(path: &str) -> Vec<String> {

--- a/crates/syster-base/src/semantic/symbol_table.rs
+++ b/crates/syster-base/src/semantic/symbol_table.rs
@@ -4,7 +4,7 @@ mod scope;
 mod symbol;
 mod table;
 
-pub use scope::Import;
+pub use scope::{Import, Scope};
 pub use symbol::{Symbol, SymbolReference};
 pub use table::SymbolTable;
 

--- a/crates/syster-base/src/semantic/symbol_table/scope.rs
+++ b/crates/syster-base/src/semantic/symbol_table/scope.rs
@@ -14,7 +14,7 @@ pub struct Import {
 
 /// Represents a lexical scope in the symbol table
 #[derive(Debug)]
-pub(super) struct Scope {
+pub struct Scope {
     pub parent: Option<usize>,
     pub symbols: HashMap<String, Symbol>,
     pub children: Vec<usize>,

--- a/crates/syster-base/src/semantic/symbol_table/tests/tests_symbol_table.rs
+++ b/crates/syster-base/src/semantic/symbol_table/tests/tests_symbol_table.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::unwrap_used)]
+use crate::semantic::resolver::Resolver;
 
 use crate::semantic::{SymbolTable, symbol_table::Symbol};
 
@@ -23,7 +24,8 @@ fn test_insert_and_lookup() {
     table
         .insert("MyPackage".to_string(), symbol.clone())
         .unwrap();
-    let found = table.lookup("MyPackage");
+    let _resolver = Resolver::new(&table);
+    let found = _resolver.resolve("MyPackage");
     assert!(found.is_some());
     assert_eq!(found.unwrap(), &symbol);
 }
@@ -74,13 +76,13 @@ fn test_scope_hierarchy() {
     };
     table.insert("MyClass".to_string(), class_symbol).unwrap();
 
-    assert!(table.lookup("Root").is_some());
-    assert!(table.lookup("MyClass").is_some());
+    assert!(Resolver::new(&table).resolve("Root").is_some());
+    assert!(Resolver::new(&table).resolve("MyClass").is_some());
 
     table.exit_scope();
 
-    assert!(table.lookup("Root").is_some());
-    assert!(table.lookup("MyClass").is_none());
+    assert!(Resolver::new(&table).resolve("Root").is_some());
+    assert!(Resolver::new(&table).resolve("MyClass").is_none());
 }
 
 #[test]
@@ -162,17 +164,17 @@ fn test_multiple_nested_scopes() {
         )
         .unwrap();
 
-    assert!(table.lookup("Level0").is_some());
-    assert!(table.lookup("Level1").is_some());
-    assert!(table.lookup("Level2").is_some());
+    assert!(Resolver::new(&table).resolve("Level0").is_some());
+    assert!(Resolver::new(&table).resolve("Level1").is_some());
+    assert!(Resolver::new(&table).resolve("Level2").is_some());
 
     table.exit_scope();
-    assert!(table.lookup("Level2").is_none());
-    assert!(table.lookup("Level1").is_some());
+    assert!(Resolver::new(&table).resolve("Level2").is_none());
+    assert!(Resolver::new(&table).resolve("Level1").is_some());
 
     table.exit_scope();
-    assert!(table.lookup("Level1").is_none());
-    assert!(table.lookup("Level0").is_some());
+    assert!(Resolver::new(&table).resolve("Level1").is_none());
+    assert!(Resolver::new(&table).resolve("Level0").is_some());
 }
 
 #[test]
@@ -257,11 +259,11 @@ fn test_different_symbol_types() {
         )
         .unwrap();
 
-    assert!(table.lookup("MyPackage").is_some());
-    assert!(table.lookup("MyClass").is_some());
-    assert!(table.lookup("MyFeature").is_some());
-    assert!(table.lookup("MyDef").is_some());
-    assert!(table.lookup("MyUsage").is_some());
+    assert!(Resolver::new(&table).resolve("MyPackage").is_some());
+    assert!(Resolver::new(&table).resolve("MyClass").is_some());
+    assert!(Resolver::new(&table).resolve("MyFeature").is_some());
+    assert!(Resolver::new(&table).resolve("MyDef").is_some());
+    assert!(Resolver::new(&table).resolve("MyUsage").is_some());
 
     let all = table.all_symbols();
     assert_eq!(all.len(), 5);
@@ -280,7 +282,7 @@ fn test_exit_scope_at_root() {
 #[test]
 fn test_lookup_nonexistent_symbol() {
     let table = SymbolTable::new();
-    assert!(table.lookup("DoesNotExist").is_none());
+    assert!(Resolver::new(&table).resolve("DoesNotExist").is_none());
 }
 
 #[test]
@@ -339,9 +341,9 @@ fn test_remove_symbols_from_file() {
         .unwrap();
 
     // Verify all symbols exist
-    assert!(table.lookup("Pkg1").is_some());
-    assert!(table.lookup("Pkg2").is_some());
-    assert!(table.lookup("Class1").is_some());
+    assert!(Resolver::new(&table).resolve("Pkg1").is_some());
+    assert!(Resolver::new(&table).resolve("Pkg2").is_some());
+    assert!(Resolver::new(&table).resolve("Class1").is_some());
 
     // Remove file1 symbols
     let removed = table.remove_symbols_from_file("file1.sysml");
@@ -350,9 +352,9 @@ fn test_remove_symbols_from_file() {
     assert_eq!(removed, 2);
 
     // Verify file1 symbols are gone
-    assert!(table.lookup("Pkg1").is_none());
-    assert!(table.lookup("Class1").is_none());
+    assert!(Resolver::new(&table).resolve("Pkg1").is_none());
+    assert!(Resolver::new(&table).resolve("Class1").is_none());
 
     // Verify file2 symbols remain
-    assert!(table.lookup("Pkg2").is_some());
+    assert!(Resolver::new(&table).resolve("Pkg2").is_some());
 }

--- a/crates/syster-base/src/semantic/workspace/population.rs
+++ b/crates/syster-base/src/semantic/workspace/population.rs
@@ -1,3 +1,5 @@
+use crate::core::constants::REL_TYPING;
+use crate::semantic::resolver::Resolver;
 use crate::semantic::workspace::{Workspace, populator::WorkspacePopulator};
 use crate::syntax::SyntaxFile;
 use std::path::PathBuf;
@@ -16,6 +18,9 @@ impl Workspace<SyntaxFile> {
             self.mark_file_populated(&path);
         }
 
+        // Resolve relationship targets after all symbols are populated
+        self.resolve_relationship_targets();
+
         Ok(())
     }
 
@@ -33,6 +38,9 @@ impl Workspace<SyntaxFile> {
             self.mark_file_populated(&path);
         }
 
+        // Resolve relationship targets after population
+        self.resolve_relationship_targets();
+
         Ok(count)
     }
 
@@ -45,6 +53,31 @@ impl Workspace<SyntaxFile> {
         );
         populator.populate_file(path)?;
         self.mark_file_populated(path);
+
+        // Resolve relationship targets after population
+        self.resolve_relationship_targets();
+
         Ok(())
+    }
+
+    /// Resolves unqualified targets in relationships to their fully qualified names.
+    /// This runs after population when all symbols are available.
+    fn resolve_relationship_targets(&mut self) {
+        let resolver = Resolver::new(&self.symbol_table);
+
+        self.relationship_graph
+            .resolve_targets(REL_TYPING, |source, target| {
+                // Get the scope of the source symbol to resolve in the correct context
+                let scope_id = self
+                    .symbol_table
+                    .find_by_qualified_name(source)
+                    .map(|sym| sym.scope_id())
+                    .unwrap_or(0);
+
+                // Resolve the target name in that scope (handles imports, scope chain)
+                resolver
+                    .resolve_in_scope(target, scope_id)
+                    .map(|sym| sym.qualified_name().to_string())
+            });
     }
 }

--- a/crates/syster-base/src/semantic/workspace/tests/tests_workspace.rs
+++ b/crates/syster-base/src/semantic/workspace/tests/tests_workspace.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::unwrap_used)]
+use crate::semantic::resolver::Resolver;
 
 use std::path::PathBuf;
 
@@ -47,7 +48,8 @@ fn test_populate_single_file() {
     assert!(result.is_ok(), "Failed to populate: {:?}", result.err());
 
     // Verify symbol was added to the shared symbol table
-    let symbol = workspace.symbol_table().lookup("Vehicle");
+    let _resolver = Resolver::new(workspace.symbol_table());
+    let symbol = _resolver.resolve("Vehicle");
     assert!(symbol.is_some());
     assert_eq!(symbol.unwrap().source_file(), Some("vehicle.sysml"));
 }
@@ -79,11 +81,13 @@ fn test_populate_multiple_files() {
     assert!(result.is_ok(), "Failed to populate: {:?}", result.err());
 
     // Verify both symbols are in the shared symbol table
-    let vehicle = workspace.symbol_table().lookup("Vehicle");
+    let _resolver = Resolver::new(workspace.symbol_table());
+    let vehicle = _resolver.resolve("Vehicle");
     assert!(vehicle.is_some());
     assert_eq!(vehicle.unwrap().source_file(), Some("vehicle.sysml"));
 
-    let car = workspace.symbol_table().lookup("Car");
+    let _resolver = Resolver::new(workspace.symbol_table());
+    let car = _resolver.resolve("Car");
     assert!(car.is_some());
     assert_eq!(car.unwrap().source_file(), Some("car.sysml"));
 
@@ -110,7 +114,8 @@ fn test_update_file_content() {
     workspace.populate_file(&path).unwrap();
 
     // Verify initial content
-    let symbol = workspace.symbol_table().lookup("Vehicle");
+    let _resolver = Resolver::new(workspace.symbol_table());
+    let symbol = _resolver.resolve("Vehicle");
     assert!(symbol.is_some());
 
     // Get initial version
@@ -1463,7 +1468,8 @@ fn test_symbol_table_mut_basic() {
         .unwrap();
 
     // Verify it was added
-    let lookup = workspace.symbol_table().lookup("TestPackage");
+    let _resolver = Resolver::new(workspace.symbol_table());
+    let lookup = _resolver.resolve("TestPackage");
     assert!(lookup.is_some());
 }
 
@@ -1504,8 +1510,8 @@ fn test_symbol_table_mut_allows_modifications() {
         .unwrap();
 
     // Verify both exist
-    assert!(workspace.symbol_table().lookup("Symbol1").is_some());
-    assert!(workspace.symbol_table().lookup("Symbol2").is_some());
+    assert!(Resolver::new(workspace.symbol_table()).resolve("Symbol1").is_some());
+    assert!(Resolver::new(workspace.symbol_table()).resolve("Symbol2").is_some());
 }
 
 #[test]
@@ -1531,7 +1537,8 @@ fn test_symbol_table_mut_independent_from_immutable() {
         .unwrap();
 
     // Access via immutable reference
-    let symbol = workspace.symbol_table().lookup("Test");
+    let _resolver = Resolver::new(workspace.symbol_table());
+    let symbol = _resolver.resolve("Test");
     assert!(symbol.is_some());
     assert_eq!(symbol.unwrap().name(), "Test");
 }

--- a/crates/syster-base/src/syntax/file.rs
+++ b/crates/syster-base/src/syntax/file.rs
@@ -1,5 +1,6 @@
 use crate::syntax::kerml::KerMLFile;
-use crate::syntax::sysml::ast::SysMLFile;
+use crate::syntax::kerml::ast::Element as KerMLElement;
+use crate::syntax::sysml::ast::{Element as SysMLElement, SysMLFile};
 
 /// A parsed syntax file that can be either SysML or KerML
 #[derive(Debug, Clone, PartialEq)]
@@ -8,12 +9,40 @@ pub enum SyntaxFile {
     KerML(KerMLFile),
 }
 
+/// Extract import paths from a SysML file
+pub fn extract_sysml_imports(file: &SysMLFile) -> Vec<String> {
+    file.elements
+        .iter()
+        .filter_map(|element| {
+            if let SysMLElement::Import(import) = element {
+                Some(import.path.clone())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// Extract import paths from a KerML file
+pub fn extract_kerml_imports(file: &KerMLFile) -> Vec<String> {
+    file.elements
+        .iter()
+        .filter_map(|element| {
+            if let KerMLElement::Import(import) = element {
+                Some(import.path.clone())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
 // Implement ParsedFile trait for semantic layer
 impl crate::semantic::ParsedFile for SyntaxFile {
     fn extract_imports(&self) -> Vec<String> {
         match self {
-            SyntaxFile::SysML(sysml_file) => crate::semantic::extract_imports(sysml_file),
-            SyntaxFile::KerML(kerml_file) => crate::semantic::extract_kerml_imports(kerml_file),
+            SyntaxFile::SysML(sysml_file) => extract_sysml_imports(sysml_file),
+            SyntaxFile::KerML(kerml_file) => extract_kerml_imports(kerml_file),
         }
     }
 }

--- a/crates/syster-base/tests/parser/tests_span.rs
+++ b/crates/syster-base/tests/parser/tests_span.rs
@@ -10,6 +10,7 @@
 
 use std::path::PathBuf;
 use syster::core::Position;
+use syster::semantic::resolver::Resolver;
 use syster::syntax::SyntaxFile;
 use syster::syntax::parser::parse_with_result;
 use syster::syntax::sysml::ast::SysMLFile;
@@ -323,10 +324,11 @@ part myVehicle: Vehicle;"#;
     assert!(result.is_ok(), "Symbol population failed: {result:?}");
 
     let symbol_table = workspace.symbol_table();
+    let resolver = Resolver::new(&symbol_table);
 
     // Check that Package symbol has span
-    let package_symbol = symbol_table
-        .lookup("Test")
+    let package_symbol = resolver
+        .resolve("Test")
         .expect("Package 'Test' should be in symbol table");
     assert!(
         package_symbol.span().is_some(),
@@ -334,8 +336,8 @@ part myVehicle: Vehicle;"#;
     );
 
     // Check that Definition symbol has span
-    let def_symbol = symbol_table
-        .lookup_qualified("Test::Vehicle")
+    let def_symbol = resolver
+        .resolve_qualified("Test::Vehicle")
         .expect("Definition 'Test::Vehicle' should be in symbol table");
     assert!(
         def_symbol.span().is_some(),
@@ -343,8 +345,8 @@ part myVehicle: Vehicle;"#;
     );
 
     // Check that Usage symbol has span
-    let usage_symbol = symbol_table
-        .lookup_qualified("Test::myVehicle")
+    let usage_symbol = resolver
+        .resolve_qualified("Test::myVehicle")
         .expect("Usage 'Test::myVehicle' should be in symbol table");
     assert!(
         usage_symbol.span().is_some(),

--- a/crates/syster-base/tests/semantic/tests_import.rs
+++ b/crates/syster-base/tests/semantic/tests_import.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::unwrap_used)]
+use syster::semantic::resolver::Resolver;
 
 use from_pest::FromPest;
 use pest::Parser;
@@ -59,11 +60,13 @@ fn test_import_membership() {
     assert!(result.is_ok(), "Failed to populate: {:?}", result.err());
 
     // Vehicle should be accessible in Derived package due to import
-    let my_car = workspace.symbol_table().lookup_qualified("Derived::myCar");
+    let _resolver = Resolver::new(workspace.symbol_table());
+    let my_car = _resolver.resolve_qualified("Derived::myCar");
     assert!(my_car.is_some(), "myCar should be defined");
 
     // Verify that Base::Vehicle can be found (the imported member)
-    let vehicle = workspace.symbol_table().lookup_qualified("Base::Vehicle");
+    let _resolver = Resolver::new(workspace.symbol_table());
+    let vehicle = _resolver.resolve_qualified("Base::Vehicle");
     assert!(
         vehicle.is_some(),
         "Base::Vehicle should exist and be importable"
@@ -102,14 +105,14 @@ fn test_import_membership_with_namespace() {
     assert!(result.is_ok(), "Failed to populate: {:?}", result.err());
 
     // Member import: only Vehicle should be accessible in Derived1
-    let car1 = workspace.symbol_table().lookup_qualified("Derived1::myCar");
+    let _resolver = Resolver::new(workspace.symbol_table());
+    let car1 = _resolver.resolve_qualified("Derived1::myCar");
     assert!(car1.is_some(), "Derived1::myCar should be defined");
 
     // Namespace import: both Vehicle and Engine should be accessible in Derived2
-    let car2 = workspace.symbol_table().lookup_qualified("Derived2::myCar");
-    let engine2 = workspace
-        .symbol_table()
-        .lookup_qualified("Derived2::myEngine");
+    let resolver = Resolver::new(workspace.symbol_table());
+    let car2 = resolver.resolve_qualified("Derived2::myCar");
+    let engine2 = resolver.resolve_qualified("Derived2::myEngine");
     assert!(car2.is_some(), "Derived2::myCar should be defined");
     assert!(engine2.is_some(), "Derived2::myEngine should be defined");
 }
@@ -142,8 +145,10 @@ fn test_import_namespace() {
     assert!(result.is_ok(), "Failed to populate: {:?}", result.err());
 
     // Both Vehicle and Engine should be accessible via namespace import
-    let car = workspace.symbol_table().lookup_qualified("Derived::car");
-    let engine = workspace.symbol_table().lookup_qualified("Derived::engine");
+    let _resolver = Resolver::new(workspace.symbol_table());
+    let car = _resolver.resolve_qualified("Derived::car");
+    let _resolver = Resolver::new(workspace.symbol_table());
+    let engine = _resolver.resolve_qualified("Derived::engine");
 
     assert!(car.is_some(), "car should be defined");
     assert!(engine.is_some(), "engine should be defined");
@@ -183,7 +188,8 @@ fn test_cross_file_import() {
     assert!(result.is_ok(), "Failed to populate: {:?}", result.err());
 
     // Car should be able to specialize Vehicle from the imported package
-    let car = workspace.symbol_table().lookup_qualified("Car");
+    let _resolver = Resolver::new(workspace.symbol_table());
+    let car = _resolver.resolve_qualified("Car");
     assert!(car.is_some(), "Car should be defined");
 }
 
@@ -215,7 +221,8 @@ fn test_import_visibility() {
     workspace.populate_all().expect("Population should succeed");
 
     // With model-level imports, both should work
-    let y = workspace.symbol_table().lookup_qualified("B::y");
+    let _resolver = Resolver::new(workspace.symbol_table());
+    let y = _resolver.resolve_qualified("B::y");
     assert!(y.is_some(), "y should be defined in package B");
 }
 
@@ -278,20 +285,19 @@ fn test_import_alias() {
     assert!(result.is_ok(), "Failed to populate: {:?}", result.err());
 
     // Verify that Car can reference BaseVehicle (the alias)
-    let car = workspace.symbol_table().lookup_qualified("Derived::Car");
+    let resolver = Resolver::new(workspace.symbol_table());
+    let car = resolver.resolve_qualified("Derived::Car");
     assert!(car.is_some(), "Car should be defined");
 
     // Verify that BaseVehicle resolves to Vehicle
-    let base_vehicle = workspace
-        .symbol_table()
-        .lookup_qualified("Derived::BaseVehicle");
+    let base_vehicle = resolver.resolve_qualified("Derived::BaseVehicle");
     assert!(
         base_vehicle.is_some(),
         "BaseVehicle alias should be defined in Derived package"
     );
 
     // Verify that the alias actually points to the Vehicle definition
-    let vehicle = workspace.symbol_table().lookup_qualified("Base::Vehicle");
+    let vehicle = resolver.resolve_qualified("Base::Vehicle");
     assert!(
         vehicle.is_some(),
         "Vehicle should be defined in Base package"

--- a/crates/syster-base/tests/semantic/tests_sysml_graph.rs
+++ b/crates/syster-base/tests/semantic/tests_sysml_graph.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::unwrap_used)]
+use syster::semantic::resolver::Resolver;
 
 use from_pest::FromPest;
 use pest::Parser;
@@ -41,9 +42,9 @@ fn test_end_to_end_relationship_population() {
     assert!(result.is_ok(), "Failed to populate: {:?}", result.err());
 
     // Verify symbols are in the table
-    assert!(symbol_table.lookup("Vehicle").is_some());
-    assert!(symbol_table.lookup("Car").is_some());
-    assert!(symbol_table.lookup("myCar").is_some());
+    assert!(Resolver::new(&symbol_table).resolve("Vehicle").is_some());
+    assert!(Resolver::new(&symbol_table).resolve("Car").is_some());
+    assert!(Resolver::new(&symbol_table).resolve("myCar").is_some());
 
     // Verify specialization relationship (Car :> Vehicle)
     let car_specializes = relationship_graph.get_one_to_many(REL_SPECIALIZATION, "Car");
@@ -414,8 +415,8 @@ fn test_satisfy_requirement_relationship() {
     populator.populate(&file).unwrap();
 
     // Verify symbols exist
-    assert!(symbol_table.lookup("SafetyReq").is_some());
-    assert!(symbol_table.lookup("SafetyCase").is_some());
+    assert!(Resolver::new(&symbol_table).resolve("SafetyReq").is_some());
+    assert!(Resolver::new(&symbol_table).resolve("SafetyCase").is_some());
 
     // Verify satisfy relationship
     let satisfies = relationship_graph.get_one_to_many(REL_SATISFY, "SafetyCase");
@@ -462,8 +463,8 @@ fn test_perform_action_relationship() {
     populator.populate(&file).unwrap();
 
     // Verify symbols exist
-    assert!(symbol_table.lookup("Move").is_some());
-    assert!(symbol_table.lookup("Robot").is_some());
+    assert!(Resolver::new(&symbol_table).resolve("Move").is_some());
+    assert!(Resolver::new(&symbol_table).resolve("Robot").is_some());
 
     // Verify perform relationship
     let performs = relationship_graph.get_one_to_many(REL_PERFORM, "Robot");
@@ -487,11 +488,11 @@ fn test_exhibit_state_relationship() {
 
     // Verify symbols exist
     assert!(
-        symbol_table.lookup("Moving").is_some(),
+        Resolver::new(&symbol_table).resolve("Moving").is_some(),
         "Moving symbol not found"
     );
     assert!(
-        symbol_table.lookup("Vehicle").is_some(),
+        Resolver::new(&symbol_table).resolve("Vehicle").is_some(),
         "Vehicle symbol not found"
     );
 
@@ -516,8 +517,8 @@ fn test_include_use_case_relationship() {
     populator.populate(&file).unwrap();
 
     // Verify symbols exist
-    assert!(symbol_table.lookup("Login").is_some());
-    assert!(symbol_table.lookup("ManageAccount").is_some());
+    assert!(Resolver::new(&symbol_table).resolve("Login").is_some());
+    assert!(Resolver::new(&symbol_table).resolve("ManageAccount").is_some());
 
     // Verify include relationship
     let includes = relationship_graph.get_one_to_many(REL_INCLUDE, "ManageAccount");
@@ -681,8 +682,8 @@ fn test_derived_requirement_modifier() {
     populator.populate(&file).unwrap();
 
     // Both requirements exist (nested and top-level with same name)
-    assert!(symbol_table.lookup("BaseReq").is_some());
-    assert!(symbol_table.lookup("childReq").is_some());
+    assert!(Resolver::new(&symbol_table).resolve("BaseReq").is_some());
+    assert!(Resolver::new(&symbol_table).resolve("childReq").is_some());
 
     // No subsetting relationship since there's no :> clause
     assert_eq!(

--- a/crates/syster-base/tests/tests_documentation.rs
+++ b/crates/syster-base/tests/tests_documentation.rs
@@ -41,7 +41,7 @@ fn test_workspace_api_exists() {
 
     // Verify they work correctly
     assert!(
-        symbol_table.lookup("NonExistent").is_none(),
+        Resolver::new(&symbol_table).resolve("NonExistent").is_none(),
         "Empty workspace should have no symbols"
     );
 }

--- a/crates/syster-base/tests/tests_parser_span.rs
+++ b/crates/syster-base/tests/tests_parser_span.rs
@@ -10,6 +10,7 @@
 
 use std::path::PathBuf;
 use syster::core::Position;
+use syster::semantic::resolver::Resolver;
 use syster::syntax::SyntaxFile;
 use syster::syntax::parser::parse_with_result;
 use syster::syntax::sysml::ast::SysMLFile;
@@ -323,10 +324,11 @@ part myVehicle: Vehicle;"#;
     assert!(result.is_ok(), "Symbol population failed: {result:?}");
 
     let symbol_table = workspace.symbol_table();
+    let resolver = Resolver::new(&symbol_table);
 
     // Check that Package symbol has span
-    let package_symbol = symbol_table
-        .lookup("Test")
+    let package_symbol = resolver
+        .resolve("Test")
         .expect("Package 'Test' should be in symbol table");
     assert!(
         package_symbol.span().is_some(),
@@ -334,8 +336,8 @@ part myVehicle: Vehicle;"#;
     );
 
     // Check that Definition symbol has span
-    let def_symbol = symbol_table
-        .lookup_qualified("Test::Vehicle")
+    let def_symbol = resolver
+        .resolve_qualified("Test::Vehicle")
         .expect("Definition 'Test::Vehicle' should be in symbol table");
     assert!(
         def_symbol.span().is_some(),
@@ -343,8 +345,8 @@ part myVehicle: Vehicle;"#;
     );
 
     // Check that Usage symbol has span
-    let usage_symbol = symbol_table
-        .lookup_qualified("Test::myVehicle")
+    let usage_symbol = resolver
+        .resolve_qualified("Test::myVehicle")
         .expect("Usage 'Test::myVehicle' should be in symbol table");
     assert!(
         usage_symbol.span().is_some(),

--- a/crates/syster-base/tests/tests_semantic_import.rs
+++ b/crates/syster-base/tests/tests_semantic_import.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::unwrap_used)]
+use syster::semantic::resolver::Resolver;
 
 use from_pest::FromPest;
 use pest::Parser;
@@ -59,11 +60,13 @@ fn test_import_membership() {
     assert!(result.is_ok(), "Failed to populate: {:?}", result.err());
 
     // Vehicle should be accessible in Derived package due to import
-    let my_car = workspace.symbol_table().lookup_qualified("Derived::myCar");
+    let _resolver = Resolver::new(workspace.symbol_table());
+    let my_car = _resolver.resolve_qualified("Derived::myCar");
     assert!(my_car.is_some(), "myCar should be defined");
 
     // Verify that Base::Vehicle can be found (the imported member)
-    let vehicle = workspace.symbol_table().lookup_qualified("Base::Vehicle");
+    let _resolver = Resolver::new(workspace.symbol_table());
+    let vehicle = _resolver.resolve_qualified("Base::Vehicle");
     assert!(
         vehicle.is_some(),
         "Base::Vehicle should exist and be importable"
@@ -102,14 +105,14 @@ fn test_import_membership_with_namespace() {
     assert!(result.is_ok(), "Failed to populate: {:?}", result.err());
 
     // Member import: only Vehicle should be accessible in Derived1
-    let car1 = workspace.symbol_table().lookup_qualified("Derived1::myCar");
+    let _resolver = Resolver::new(workspace.symbol_table());
+    let car1 = _resolver.resolve_qualified("Derived1::myCar");
     assert!(car1.is_some(), "Derived1::myCar should be defined");
 
     // Namespace import: both Vehicle and Engine should be accessible in Derived2
-    let car2 = workspace.symbol_table().lookup_qualified("Derived2::myCar");
-    let engine2 = workspace
-        .symbol_table()
-        .lookup_qualified("Derived2::myEngine");
+    let resolver = Resolver::new(workspace.symbol_table());
+    let car2 = resolver.resolve_qualified("Derived2::myCar");
+    let engine2 = resolver.resolve_qualified("Derived2::myEngine");
     assert!(car2.is_some(), "Derived2::myCar should be defined");
     assert!(engine2.is_some(), "Derived2::myEngine should be defined");
 }
@@ -142,8 +145,10 @@ fn test_import_namespace() {
     assert!(result.is_ok(), "Failed to populate: {:?}", result.err());
 
     // Both Vehicle and Engine should be accessible via namespace import
-    let car = workspace.symbol_table().lookup_qualified("Derived::car");
-    let engine = workspace.symbol_table().lookup_qualified("Derived::engine");
+    let _resolver = Resolver::new(workspace.symbol_table());
+    let car = _resolver.resolve_qualified("Derived::car");
+    let _resolver = Resolver::new(workspace.symbol_table());
+    let engine = _resolver.resolve_qualified("Derived::engine");
 
     assert!(car.is_some(), "car should be defined");
     assert!(engine.is_some(), "engine should be defined");
@@ -183,7 +188,8 @@ fn test_cross_file_import() {
     assert!(result.is_ok(), "Failed to populate: {:?}", result.err());
 
     // Car should be able to specialize Vehicle from the imported package
-    let car = workspace.symbol_table().lookup_qualified("Car");
+    let _resolver = Resolver::new(workspace.symbol_table());
+    let car = _resolver.resolve_qualified("Car");
     assert!(car.is_some(), "Car should be defined");
 }
 
@@ -215,7 +221,8 @@ fn test_import_visibility() {
     workspace.populate_all().expect("Population should succeed");
 
     // With model-level imports, both should work
-    let y = workspace.symbol_table().lookup_qualified("B::y");
+    let _resolver = Resolver::new(workspace.symbol_table());
+    let y = _resolver.resolve_qualified("B::y");
     assert!(y.is_some(), "y should be defined in package B");
 }
 
@@ -278,20 +285,20 @@ fn test_import_alias() {
     assert!(result.is_ok(), "Failed to populate: {:?}", result.err());
 
     // Verify that Car can reference BaseVehicle (the alias)
-    let car = workspace.symbol_table().lookup_qualified("Derived::Car");
+    let _resolver = Resolver::new(workspace.symbol_table());
+    let car = _resolver.resolve_qualified("Derived::Car");
     assert!(car.is_some(), "Car should be defined");
 
     // Verify that BaseVehicle resolves to Vehicle
-    let base_vehicle = workspace
-        .symbol_table()
-        .lookup_qualified("Derived::BaseVehicle");
+    let resolver = Resolver::new(workspace.symbol_table());
+    let base_vehicle = resolver.resolve_qualified("Derived::BaseVehicle");
     assert!(
         base_vehicle.is_some(),
         "BaseVehicle alias should be defined in Derived package"
     );
 
     // Verify that the alias actually points to the Vehicle definition
-    let vehicle = workspace.symbol_table().lookup_qualified("Base::Vehicle");
+    let vehicle = resolver.resolve_qualified("Base::Vehicle");
     assert!(
         vehicle.is_some(),
         "Vehicle should be defined in Base package"

--- a/crates/syster-base/tests/tests_semantic_resolver.rs
+++ b/crates/syster-base/tests/tests_semantic_resolver.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::unwrap_used)]
-#![allow(clippy::panic)]
 
+#![allow(clippy::panic)]
 use syster::semantic::{
     Resolver, SymbolTable, extract_imports, is_wildcard_import, parse_import_path,
     symbol_table::Symbol,
@@ -1107,7 +1107,8 @@ fn test_resolve_in_scope_qualified_name() {
     let scope_id = table.current_scope_id();
 
     // Should find by qualified name from any scope
-    let result = table.resolve_in_scope("Base::Vehicle", scope_id);
+    let _resolver = Resolver::new(&table);
+    let result = _resolver.resolve_in_scope("Base::Vehicle", scope_id);
     assert!(result.is_some());
     assert_eq!(result.unwrap().qualified_name(), "Base::Vehicle");
 }
@@ -1159,12 +1160,14 @@ fn test_resolve_in_scope_with_import() {
     let scope_without_import = table.current_scope_id();
 
     // From scope with import, should resolve "Vehicle" via import
-    let result = table.resolve_in_scope("Vehicle", scope_with_import);
+    let _resolver = Resolver::new(&table);
+    let result = _resolver.resolve_in_scope("Vehicle", scope_with_import);
     assert!(result.is_some(), "Should find Vehicle via import");
     assert_eq!(result.unwrap().qualified_name(), "Base::Vehicle");
 
     // From scope without import, should NOT find "Vehicle"
-    let result = table.resolve_in_scope("Vehicle", scope_without_import);
+    let _resolver = Resolver::new(&table);
+    let result = _resolver.resolve_in_scope("Vehicle", scope_without_import);
     assert!(result.is_none(), "Should not find Vehicle without import");
 }
 
@@ -1205,30 +1208,35 @@ fn test_resolve_in_scope_direct_symbol() {
         .unwrap();
 
     // From child scope, should find local symbol by simple name
-    let result = table.resolve_in_scope("LocalDef", child_scope);
+    let _resolver = Resolver::new(&table);
+    let result = _resolver.resolve_in_scope("LocalDef", child_scope);
     assert!(result.is_some(), "Should find LocalDef from child scope");
 
     // From child scope, should find parent symbol
-    let result = table.resolve_in_scope("GlobalPackage", child_scope);
+    let _resolver = Resolver::new(&table);
+    let result = _resolver.resolve_in_scope("GlobalPackage", child_scope);
     assert!(
         result.is_some(),
         "Should find GlobalPackage from child scope"
     );
 
     // From root scope (0), should find global
-    let result = table.resolve_in_scope("GlobalPackage", 0);
+    let _resolver = Resolver::new(&table);
+    let result = _resolver.resolve_in_scope("GlobalPackage", 0);
     assert!(result.is_some());
 
     // From root scope (0), should NOT find LocalDef by simple name
     // (it's not in scope 0's symbols, not imported, and lookup walks UP not DOWN)
-    let result = table.resolve_in_scope("LocalDef", 0);
+    let _resolver = Resolver::new(&table);
+    let result = _resolver.resolve_in_scope("LocalDef", 0);
     assert!(
         result.is_none(),
         "Should not find LocalDef by simple name from root"
     );
 
     // But SHOULD find it by qualified name from anywhere
-    let result = table.resolve_in_scope("GlobalPackage::LocalDef", 0);
+    let _resolver = Resolver::new(&table);
+    let result = _resolver.resolve_in_scope("GlobalPackage::LocalDef", 0);
     assert!(
         result.is_some(),
         "Should find by qualified name from any scope"

--- a/crates/syster-base/tests/tests_semantic_workspace.rs
+++ b/crates/syster-base/tests/tests_semantic_workspace.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::unwrap_used)]
+use syster::semantic::resolver::Resolver;
 use syster::semantic::Workspace;
 
 use std::path::PathBuf;
@@ -47,7 +48,8 @@ fn test_populate_single_file() {
     assert!(result.is_ok(), "Failed to populate: {:?}", result.err());
 
     // Verify symbol was added to the shared symbol table
-    let symbol = workspace.symbol_table().lookup("Vehicle");
+    let _resolver = Resolver::new(workspace.symbol_table());
+    let symbol = _resolver.resolve("Vehicle");
     assert!(symbol.is_some());
     assert_eq!(symbol.unwrap().source_file(), Some("vehicle.sysml"));
 }
@@ -79,11 +81,13 @@ fn test_populate_multiple_files() {
     assert!(result.is_ok(), "Failed to populate: {:?}", result.err());
 
     // Verify both symbols are in the shared symbol table
-    let vehicle = workspace.symbol_table().lookup("Vehicle");
+    let _resolver = Resolver::new(workspace.symbol_table());
+    let vehicle = _resolver.resolve("Vehicle");
     assert!(vehicle.is_some());
     assert_eq!(vehicle.unwrap().source_file(), Some("vehicle.sysml"));
 
-    let car = workspace.symbol_table().lookup("Car");
+    let _resolver = Resolver::new(workspace.symbol_table());
+    let car = _resolver.resolve("Car");
     assert!(car.is_some());
     assert_eq!(car.unwrap().source_file(), Some("car.sysml"));
 
@@ -110,7 +114,8 @@ fn test_update_file_content() {
     workspace.populate_file(&path).unwrap();
 
     // Verify initial content
-    let symbol = workspace.symbol_table().lookup("Vehicle");
+    let _resolver = Resolver::new(workspace.symbol_table());
+    let symbol = _resolver.resolve("Vehicle");
     assert!(symbol.is_some());
 
     // Get initial version
@@ -1411,7 +1416,8 @@ fn test_symbol_table_mut_basic() {
         .unwrap();
 
     // Verify it was added
-    let lookup = workspace.symbol_table().lookup("TestPackage");
+    let _resolver = Resolver::new(workspace.symbol_table());
+    let lookup = _resolver.resolve("TestPackage");
     assert!(lookup.is_some());
 }
 
@@ -1452,8 +1458,8 @@ fn test_symbol_table_mut_allows_modifications() {
         .unwrap();
 
     // Verify both exist
-    assert!(workspace.symbol_table().lookup("Symbol1").is_some());
-    assert!(workspace.symbol_table().lookup("Symbol2").is_some());
+    assert!(Resolver::new(workspace.symbol_table()).resolve("Symbol1").is_some());
+    assert!(Resolver::new(workspace.symbol_table()).resolve("Symbol2").is_some());
 }
 
 #[test]
@@ -1479,7 +1485,8 @@ fn test_symbol_table_mut_independent_from_immutable() {
         .unwrap();
 
     // Access via immutable reference
-    let symbol = workspace.symbol_table().lookup("Test");
+    let _resolver = Resolver::new(workspace.symbol_table());
+    let symbol = _resolver.resolve("Test");
     assert!(symbol.is_some());
     assert_eq!(symbol.unwrap().name(), "Test");
 }

--- a/crates/syster-lsp/src/server/definition.rs
+++ b/crates/syster-lsp/src/server/definition.rs
@@ -16,8 +16,9 @@ impl LspServer {
         let path = uri_to_path(uri)?;
         let (element_name, _hover_range) = self.find_symbol_at_position(&path, position)?;
 
-        // Look up symbol in workspace
-        let symbol = self.workspace.symbol_table().resolve(&element_name)?;
+        // Look up symbol using resolver
+        let resolver = self.resolver();
+        let symbol = resolver.resolve(&element_name)?;
 
         // Get definition location from symbol
         let source_file = symbol.source_file()?;

--- a/crates/syster-lsp/src/server/document_links.rs
+++ b/crates/syster-lsp/src/server/document_links.rs
@@ -63,8 +63,9 @@ impl LspServer {
             return None;
         }
 
-        // Look up the symbol in the symbol table
-        let symbol = self.workspace.symbol_table().resolve(&symbol_name)?;
+        // Look up the symbol using resolver
+        let resolver = self.resolver();
+        let symbol = resolver.resolve(&symbol_name)?;
 
         // Get the source file for this symbol
         let source_file = symbol.source_file()?;

--- a/crates/syster-lsp/src/server/hover.rs
+++ b/crates/syster-lsp/src/server/hover.rs
@@ -13,8 +13,9 @@ impl LspServer {
         // Find symbol at position - returns qualified name string
         let (qualified_name, hover_range) = self.find_symbol_at_position(&path, position)?;
 
-        // Look up the symbol using the qualified name
-        let symbol = self.workspace.symbol_table().resolve(&qualified_name)?;
+        // Look up the symbol using the resolver
+        let resolver = self.resolver();
+        let symbol = resolver.resolve(&qualified_name)?;
 
         // Format rich hover content with relationships
         let content = format_rich_hover(symbol, self.workspace());

--- a/crates/syster-lsp/src/server/position.rs
+++ b/crates/syster-lsp/src/server/position.rs
@@ -35,21 +35,12 @@ impl LspServer {
             },
         };
 
-        // Try resolver first (works for qualified names and scope-aware lookups)
-        let resolver = self.resolver();
-        if let Some(symbol) = resolver.resolve(&word) {
-            let qualified_name = symbol.qualified_name().to_string();
-            // Use symbol's span if available, otherwise use the word range from source
-            let range = symbol
-                .span()
-                .map(|s| span_to_lsp_range(&s))
-                .unwrap_or(word_range);
-            return Some((qualified_name, range));
-        }
+        let file_path_str = path.to_string_lossy().to_string();
 
-        // Fallback: search all symbols by simple name (for cross-scope references)
+        // First, check if the word matches a symbol defined in THIS file.
+        // This handles hovering on definitions like "part def Engine".
         for (_key, symbol) in self.workspace.symbol_table().all_symbols() {
-            if symbol.name() == word {
+            if symbol.name() == word && symbol.source_file().as_deref() == Some(&file_path_str) {
                 let qualified_name = symbol.qualified_name().to_string();
                 let range = symbol
                     .span()
@@ -58,6 +49,41 @@ impl LspServer {
                 return Some((qualified_name, range));
             }
         }
+
+        // Second, try to resolve using the file's scope for proper import resolution.
+        // Use the Resolver with scope context for consistent resolution behavior.
+        let resolver = self.resolver();
+        if let Some(scope_id) = self
+            .workspace
+            .symbol_table()
+            .get_scope_for_file(&file_path_str)
+        {
+            if let Some(symbol) = resolver.resolve_in_scope(&word, scope_id) {
+                let qualified_name = symbol.qualified_name().to_string();
+                let range = symbol
+                    .span()
+                    .map(|s| span_to_lsp_range(&s))
+                    .unwrap_or(word_range);
+                return Some((qualified_name, range));
+            }
+        }
+
+        // Fallback: try resolver for qualified names (e.g., "Package::Type")
+        if word.contains("::") {
+            let resolver = self.resolver();
+            if let Some(symbol) = resolver.resolve(&word) {
+                let qualified_name = symbol.qualified_name().to_string();
+                let range = symbol
+                    .span()
+                    .map(|s| span_to_lsp_range(&s))
+                    .unwrap_or(word_range);
+                return Some((qualified_name, range));
+            }
+        }
+
+        // If resolution fails, the symbol is not in scope (e.g., import was removed).
+        // Do NOT fall back to searching all symbols by simple name - that bypasses
+        // import resolution and shows stale information.
         None
     }
 }

--- a/crates/syster-lsp/src/server/rename.rs
+++ b/crates/syster-lsp/src/server/rename.rs
@@ -10,8 +10,9 @@ impl LspServer {
         let path = uri_to_path(uri)?;
         let (element_name, range) = self.find_symbol_at_position(&path, position)?;
 
-        // Look up the symbol to verify it exists and is renamable
-        let symbol = self.workspace.symbol_table().resolve(&element_name)?;
+        // Look up the symbol using resolver to verify it exists and is renamable
+        let resolver = self.resolver();
+        let symbol = resolver.resolve(&element_name)?;
 
         // Get the simple name (last component) for display
         let simple_name = symbol.name().to_string();
@@ -36,8 +37,9 @@ impl LspServer {
         let path = uri_to_path(uri)?;
         let (element_name, _) = self.find_symbol_at_position(&path, position)?;
 
-        // Look up the symbol
-        let symbol = self.workspace.symbol_table().resolve(&element_name)?;
+        // Look up the symbol using resolver
+        let resolver = self.resolver();
+        let symbol = resolver.resolve(&element_name)?;
         let qualified_name = symbol.qualified_name();
 
         // Collect all locations (definition + references)


### PR DESCRIPTION
## Summary

This refactoring creates a cleaner separation of concerns between data storage and resolution algorithms.

## SymbolTable (pure data structure)
- Stores symbols, scopes, imports
- Provides data access methods: `find_by_qualified_name`, `get_symbol_in_scope`
- Handles mutable operations: `insert`, `lookup_mut`, `remove_symbols_from_file`
- No resolution logic - just data storage and retrieval

## Resolver (resolution algorithms)
- New `resolve_in_scope()` for file-context-aware lookups
- `walk_scope_chain()` handles scope traversal + import checking
- Import resolution moved from SymbolTable to Resolver
- All symbol lookup logic consolidated in one place

## Key changes
- Removed `lookup()`, `lookup_qualified()`, `resolve()` from SymbolTable
- Added `find_by_qualified_name()` as pure data access (no scope walking)
- Added `get_scope_for_file()` to find the scope containing a file's imports
- LSP `position.rs` now uses scope-aware resolution for correct import handling
- Import extraction functions moved to syntax layer (`file.rs`)
- ReferenceCollector uses `find_by_qualified_name` for data population

## Benefits
- Clearer API: SymbolTable for storage, Resolver for queries
- Scope-aware lookups now possible via `resolve_in_scope()`
- Fixes stale hover info when imports are removed (`position.rs`)
- Better testability - can test data and algorithms separately

## Testing
All tests updated to use `Resolver::new(&table).resolve()` pattern. 47 files changed.