### PR TITLE
Fix hardcoded debug path in stdlib test

### DIFF
--- a/crates/syster-base/src/semantic/adapters/kerml/tests/tests_visitor.rs
+++ b/crates/syster-base/src/semantic/adapters/kerml/tests/tests_visitor.rs
@@ -34,8 +34,8 @@ fn test_kerml_visitor_creates_classifier_symbol() {
     let mut adapter = KermlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let symbol = _resolver.resolve("Vehicle").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let symbol = resolver.resolve("Vehicle").unwrap();
     match symbol {
         Symbol::Classifier { kind, .. } => assert_eq!(kind, "Classifier"),
         _ => panic!("Expected Classifier symbol"),
@@ -53,8 +53,8 @@ fn test_kerml_visitor_creates_datatype_symbol() {
     let mut adapter = KermlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let symbol = _resolver.resolve("Temperature").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let symbol = resolver.resolve("Temperature").unwrap();
     match symbol {
         Symbol::Definition { kind, .. } => assert_eq!(kind, "Datatype"),
         _ => panic!("Expected Definition symbol"),
@@ -72,8 +72,8 @@ fn test_kerml_visitor_creates_feature_symbol() {
     let mut adapter = KermlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let symbol = _resolver.resolve("mass").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let symbol = resolver.resolve("mass").unwrap();
     match symbol {
         Symbol::Feature { .. } => (),
         _ => panic!("Expected Feature symbol"),
@@ -123,8 +123,8 @@ fn test_kerml_visitor_creates_function_symbol() {
     let mut adapter = KermlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let symbol = _resolver.resolve("calculateArea").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let symbol = resolver.resolve("calculateArea").unwrap();
     match symbol {
         Symbol::Definition { kind, .. } => assert_eq!(kind, "Function"),
         _ => panic!("Expected Function symbol"),
@@ -189,8 +189,8 @@ fn test_kerml_visitor_handles_abstract_classifiers() {
     let mut adapter = KermlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let symbol = _resolver.resolve("Shape").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let symbol = resolver.resolve("Shape").unwrap();
     match symbol {
         Symbol::Classifier {
             kind, is_abstract, ..
@@ -214,8 +214,8 @@ fn test_kerml_visitor_handles_readonly_features() {
     adapter.populate(&file).unwrap();
 
     // For now, just verify the symbol exists - readonly modifier tracking will be added later
-    let _resolver = Resolver::new(&symbol_table);
-    let symbol = _resolver.resolve("timestamp");
+    let resolver = Resolver::new(&symbol_table);
+    let symbol = resolver.resolve("timestamp");
     assert!(symbol.is_some(), "timestamp feature should exist");
 }
 

--- a/crates/syster-base/src/semantic/adapters/sysml/tests/tests_visitor.rs
+++ b/crates/syster-base/src/semantic/adapters/sysml/tests/tests_visitor.rs
@@ -35,8 +35,8 @@ fn test_visitor_creates_definition_symbol() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let symbol = _resolver.resolve("Vehicle").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let symbol = resolver.resolve("Vehicle").unwrap();
     match symbol {
         Symbol::Definition { kind, .. } => assert_eq!(kind, "Part"),
         _ => panic!("Expected Definition symbol"),
@@ -392,8 +392,8 @@ fn test_visitor_creates_usage_symbol() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let symbol = _resolver.resolve("myCar").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let symbol = resolver.resolve("myCar").unwrap();
     match symbol {
         Symbol::Usage { usage_type, .. } => {
             assert_eq!(usage_type.as_deref(), Some("Vehicle"));
@@ -574,22 +574,22 @@ fn test_different_definition_kinds() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let part_def = _resolver.resolve("PartDef").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let part_def = resolver.resolve("PartDef").unwrap();
     match part_def {
         Symbol::Definition { kind, .. } => assert_eq!(kind, "Part"),
         _ => panic!("Expected Definition symbol"),
     }
 
-    let _resolver = Resolver::new(&symbol_table);
-    let action_def = _resolver.resolve("ActionDef").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let action_def = resolver.resolve("ActionDef").unwrap();
     match action_def {
         Symbol::Definition { kind, .. } => assert_eq!(kind, "Action"),
         _ => panic!("Expected Definition symbol"),
     }
 
-    let _resolver = Resolver::new(&symbol_table);
-    let req_def = _resolver.resolve("ReqDef").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let req_def = resolver.resolve("ReqDef").unwrap();
     match req_def {
         Symbol::Definition { kind, .. } => assert_eq!(kind, "Requirement"),
         _ => panic!("Expected Definition symbol"),
@@ -688,8 +688,8 @@ fn test_empty_definition() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let symbol = _resolver.resolve("EmptyPart").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let symbol = resolver.resolve("EmptyPart").unwrap();
     match symbol {
         Symbol::Definition { name, .. } => assert_eq!(name, "EmptyPart"),
         _ => panic!("Expected Definition symbol"),
@@ -707,8 +707,8 @@ fn test_usage_without_type() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let symbol = _resolver.resolve("untyped").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let symbol = resolver.resolve("untyped").unwrap();
     match symbol {
         Symbol::Usage { usage_type, .. } => {
             assert_eq!(
@@ -737,8 +737,8 @@ fn test_qualified_names_are_correct() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let vehicles = _resolver.resolve("Vehicles").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let vehicles = resolver.resolve("Vehicles").unwrap();
     match vehicles {
         Symbol::Package { qualified_name, .. } => {
             assert_eq!(qualified_name, "Vehicles");
@@ -883,8 +883,8 @@ fn test_port_definition_and_usage() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let port_def = _resolver.resolve("DataPort").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let port_def = resolver.resolve("DataPort").unwrap();
     match port_def {
         Symbol::Definition { kind, .. } => {
             assert_eq!(kind, "Port");
@@ -927,8 +927,8 @@ fn test_action_with_parameters() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let action_def = _resolver.resolve("ProcessData").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let action_def = resolver.resolve("ProcessData").unwrap();
     match action_def {
         Symbol::Definition { kind, .. } => {
             assert_eq!(kind, "Action");
@@ -960,8 +960,8 @@ fn test_constraint_definition() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let constraint_def = _resolver.resolve("SpeedLimit").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let constraint_def = resolver.resolve("SpeedLimit").unwrap();
     match constraint_def {
         Symbol::Definition { kind, .. } => {
             assert_eq!(kind, "Constraint");
@@ -987,8 +987,8 @@ fn test_enumeration_definition() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let enum_def = _resolver.resolve("Color").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let enum_def = resolver.resolve("Color").unwrap();
     match enum_def {
         Symbol::Definition { kind, .. } => {
             assert_eq!(kind, "Enumeration");
@@ -1024,8 +1024,8 @@ fn test_state_definition() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let state_def = _resolver.resolve("VehicleState").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let state_def = resolver.resolve("VehicleState").unwrap();
     match state_def {
         Symbol::Definition { kind, .. } => {
             assert_eq!(kind, "State");
@@ -1045,8 +1045,8 @@ fn test_connection_definition() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let conn_def = _resolver.resolve("DataFlow").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let conn_def = resolver.resolve("DataFlow").unwrap();
     match conn_def {
         Symbol::Definition { kind, .. } => {
             assert_eq!(kind, "Connection");
@@ -1066,8 +1066,8 @@ fn test_interface_definition() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let intf_def = _resolver.resolve("NetworkInterface").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let intf_def = resolver.resolve("NetworkInterface").unwrap();
     match intf_def {
         Symbol::Definition { kind, .. } => {
             assert_eq!(kind, "Interface");
@@ -1087,8 +1087,8 @@ fn test_allocation_definition() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let alloc_def = _resolver.resolve("ResourceAllocation").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let alloc_def = resolver.resolve("ResourceAllocation").unwrap();
     match alloc_def {
         Symbol::Definition { kind, .. } => {
             assert_eq!(kind, "Allocation");
@@ -1144,8 +1144,8 @@ fn test_concern_and_requirement() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let concern = _resolver.resolve("Safety").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let concern = resolver.resolve("Safety").unwrap();
     match concern {
         Symbol::Definition { kind, .. } => {
             assert_eq!(kind, "UseCase"); // Concern maps to UseCase
@@ -1153,8 +1153,8 @@ fn test_concern_and_requirement() {
         _ => panic!("Expected Definition symbol"),
     }
 
-    let _resolver = Resolver::new(&symbol_table);
-    let requirement = _resolver.resolve("SafetyRequirement").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let requirement = resolver.resolve("SafetyRequirement").unwrap();
     match requirement {
         Symbol::Definition { kind, .. } => {
             assert_eq!(kind, "Requirement");

--- a/crates/syster-base/src/semantic/adapters/tests/tests_adapters.rs
+++ b/crates/syster-base/src/semantic/adapters/tests/tests_adapters.rs
@@ -620,8 +620,8 @@ fn test_populate_single_package() {
     let result = populator.populate(&file);
     assert!(result.is_ok());
 
-    let _resolver = Resolver::new(&table);
-    let symbol = _resolver.resolve("TestPackage");
+    let resolver = Resolver::new(&table);
+    let symbol = resolver.resolve("TestPackage");
     assert!(symbol.is_some());
 
     let Some(Symbol::Package {
@@ -658,8 +658,8 @@ fn test_populate_nested_packages() {
     let result = populator.populate(&file);
     assert!(result.is_ok());
 
-    let _resolver = Resolver::new(&table);
-    let outer = _resolver.resolve("Outer");
+    let resolver = Resolver::new(&table);
+    let outer = resolver.resolve("Outer");
     assert!(outer.is_some());
 
     // Verify Inner package exists in the symbol table with correct qualified name
@@ -698,8 +698,8 @@ fn test_populate_definition() {
     let result = populator.populate(&file);
     assert!(result.is_ok());
 
-    let _resolver = Resolver::new(&table);
-    let symbol = _resolver.resolve("MyPart");
+    let resolver = Resolver::new(&table);
+    let symbol = resolver.resolve("MyPart");
     assert!(symbol.is_some());
 }
 

--- a/crates/syster-base/src/semantic/adapters/tests/tests_kerml_adapter.rs
+++ b/crates/syster-base/src/semantic/adapters/tests/tests_kerml_adapter.rs
@@ -53,8 +53,8 @@ fn test_new_adapter_can_access_symbol_table() {
     let adapter = KermlAdapter::new(&mut table);
 
     // Verify adapter can access the symbol table
-    let _resolver = Resolver::new(&adapter.symbol_table);
-    let symbol = _resolver.resolve("TestSymbol");
+    let resolver = Resolver::new(&adapter.symbol_table);
+    let symbol = resolver.resolve("TestSymbol");
     assert!(symbol.is_some());
 }
 

--- a/crates/syster-base/src/semantic/adapters/tests/tests_sysml_adapter_sysmladapter.rs
+++ b/crates/syster-base/src/semantic/adapters/tests/tests_sysml_adapter_sysmladapter.rs
@@ -33,8 +33,8 @@ fn test_visit_namespace_creates_package_symbol() {
     assert!(result.is_ok());
 
     // Verify the namespace was added as a Package symbol
-    let _resolver = Resolver::new(&table);
-    let symbol = _resolver.resolve("TestNamespace");
+    let resolver = Resolver::new(&table);
+    let symbol = resolver.resolve("TestNamespace");
     assert!(symbol.is_some());
 
     let Some(Symbol::Package {
@@ -69,8 +69,8 @@ fn test_visit_namespace_enters_namespace_scope() {
     // After populate, the adapter should have entered the namespace
     // We can't directly test current_namespace (it's private), but we can test
     // that the namespace affects scope by checking all_symbols
-    let _resolver = Resolver::new(&table);
-    let symbol = _resolver.resolve("MyNamespace");
+    let resolver = Resolver::new(&table);
+    let symbol = resolver.resolve("MyNamespace");
     assert!(symbol.is_some());
 }
 
@@ -92,8 +92,8 @@ fn test_visit_namespace_with_empty_name() {
     assert!(result.is_ok());
 
     // Even with empty name, should create a symbol
-    let _resolver = Resolver::new(&table);
-    let symbol = _resolver.resolve("");
+    let resolver = Resolver::new(&table);
+    let symbol = resolver.resolve("");
     assert!(symbol.is_some());
 }
 
@@ -114,8 +114,8 @@ fn test_visit_namespace_with_special_characters() {
     let result = adapter.populate(&file);
     assert!(result.is_ok());
 
-    let _resolver = Resolver::new(&table);
-    let symbol = _resolver.resolve("Name_With_Underscores123");
+    let resolver = Resolver::new(&table);
+    let symbol = resolver.resolve("Name_With_Underscores123");
     assert!(symbol.is_some());
 }
 
@@ -136,8 +136,8 @@ fn test_visit_namespace_stores_scope_id() {
     let result = adapter.populate(&file);
     assert!(result.is_ok());
 
-    let _resolver = Resolver::new(&table);
-    let symbol = _resolver.resolve("ScopedNamespace");
+    let resolver = Resolver::new(&table);
+    let symbol = resolver.resolve("ScopedNamespace");
     assert!(symbol.is_some());
 
     if let Some(Symbol::Package { scope_id, .. }) = symbol {
@@ -172,8 +172,8 @@ fn test_visit_namespace_with_span() {
     let result = adapter.populate(&file);
     assert!(result.is_ok());
 
-    let _resolver = Resolver::new(&table);
-    let symbol = _resolver.resolve("SpannedNamespace");
+    let resolver = Resolver::new(&table);
+    let symbol = resolver.resolve("SpannedNamespace");
     assert!(symbol.is_some());
 
     if let Some(Symbol::Package { span, .. }) = symbol {
@@ -230,8 +230,8 @@ fn test_visit_namespace_affects_subsequent_elements() {
     assert!(result.is_ok());
 
     // The namespace should exist
-    let _resolver = Resolver::new(&table);
-    let ns_symbol = _resolver.resolve("OuterNamespace");
+    let resolver = Resolver::new(&table);
+    let ns_symbol = resolver.resolve("OuterNamespace");
     assert!(ns_symbol.is_some());
 
     // The inner part should be qualified with the namespace
@@ -266,8 +266,8 @@ fn test_visit_namespace_multiple_namespaces_not_supported() {
     assert!(result.is_ok());
 
     // Only the first namespace should be in the symbol table
-    let _resolver = Resolver::new(&table);
-    let symbol = _resolver.resolve("FirstNamespace");
+    let resolver = Resolver::new(&table);
+    let symbol = resolver.resolve("FirstNamespace");
     assert!(symbol.is_some());
 }
 
@@ -607,8 +607,8 @@ fn test_comment_before_namespace_not_typical_but_handled() {
     assert!(result.is_ok());
 
     // The namespace should still be created
-    let _resolver = Resolver::new(&table);
-    let symbol = _resolver.resolve("LateNamespace");
+    let resolver = Resolver::new(&table);
+    let symbol = resolver.resolve("LateNamespace");
     assert!(symbol.is_some());
 
     // The comment should not create a symbol

--- a/crates/syster-base/src/semantic/analyzer/tests/tests_analyzer.rs
+++ b/crates/syster-base/src/semantic/analyzer/tests/tests_analyzer.rs
@@ -726,8 +726,8 @@ fn test_context_symbol_table_reference() {
 
     let graph = RelationshipGraph::new();
     let context = AnalysisContext::new(&table, &graph);
-    let _resolver = Resolver::new(&context.symbol_table);
-    let lookup_result = _resolver.resolve("Test");
+    let resolver = Resolver::new(&context.symbol_table);
+    let lookup_result = resolver.resolve("Test");
     assert!(lookup_result.is_some());
 }
 

--- a/crates/syster-base/src/semantic/processors/tests/tests_processors.rs
+++ b/crates/syster-base/src/semantic/processors/tests/tests_processors.rs
@@ -101,8 +101,8 @@ fn test_typing_relationship_reference() {
     collector.collect();
 
     // Verify Vehicle has a reference from myCar
-    let _resolver = Resolver::new(&table);
-    let vehicle = _resolver.resolve("Vehicle").unwrap();
+    let resolver = Resolver::new(&table);
+    let vehicle = resolver.resolve("Vehicle").unwrap();
     assert_eq!(vehicle.references().len(), 1);
     assert_eq!(vehicle.references()[0].span.start.line, 5);
     assert_eq!(vehicle.references()[0].span.start.column, 0);
@@ -167,8 +167,8 @@ fn test_specialization_relationship_reference() {
     collector.collect();
 
     // Verify Vehicle has a reference from Car
-    let _resolver = Resolver::new(&table);
-    let vehicle = _resolver.resolve("Vehicle").unwrap();
+    let resolver = Resolver::new(&table);
+    let vehicle = resolver.resolve("Vehicle").unwrap();
     assert_eq!(vehicle.references().len(), 1);
     assert_eq!(vehicle.references()[0].span.start.line, 3);
 }
@@ -275,8 +275,8 @@ fn test_multiple_references_to_same_symbol() {
     collector.collect();
 
     // Verify Integer has references from all three features
-    let _resolver = Resolver::new(&table);
-    let integer = _resolver.resolve("Integer").unwrap();
+    let resolver = Resolver::new(&table);
+    let integer = resolver.resolve("Integer").unwrap();
     assert_eq!(integer.references().len(), 3);
 
     let lines: Vec<_> = integer
@@ -346,8 +346,8 @@ fn test_redefinition_reference() {
     collector.collect();
 
     // Verify Vehicle::mass has a reference from Car::mass
-    let _resolver = Resolver::new(&table);
-    let base_mass = _resolver.resolve("Vehicle::mass").unwrap();
+    let resolver = Resolver::new(&table);
+    let base_mass = resolver.resolve("Vehicle::mass").unwrap();
     assert_eq!(base_mass.references().len(), 1);
     assert_eq!(base_mass.references()[0].span.start.line, 6);
 }
@@ -409,8 +409,8 @@ fn test_subsetting_reference() {
     collector.collect();
 
     // Verify parts has a reference from engineParts
-    let _resolver = Resolver::new(&table);
-    let parts = _resolver.resolve("parts").unwrap();
+    let resolver = Resolver::new(&table);
+    let parts = resolver.resolve("parts").unwrap();
     assert_eq!(parts.references().len(), 1);
     assert_eq!(parts.references()[0].span.start.line, 4);
 }
@@ -476,8 +476,8 @@ fn test_reference_subsetting() {
     collector.collect();
 
     // Verify vehicle has a reference from car
-    let _resolver = Resolver::new(&table);
-    let vehicle = _resolver.resolve("vehicle").unwrap();
+    let resolver = Resolver::new(&table);
+    let vehicle = resolver.resolve("vehicle").unwrap();
     assert_eq!(vehicle.references().len(), 1);
     assert_eq!(vehicle.references()[0].span.start.line, 4);
 }
@@ -517,8 +517,8 @@ fn test_no_references() {
     collector.collect();
 
     // Verify no references collected
-    let _resolver = Resolver::new(&table);
-    let standalone = _resolver.resolve("StandaloneClass").unwrap();
+    let resolver = Resolver::new(&table);
+    let standalone = resolver.resolve("StandaloneClass").unwrap();
     assert_eq!(standalone.references().len(), 0);
 }
 
@@ -576,8 +576,8 @@ fn test_symbol_without_span() {
     collector.collect();
 
     // Verify no reference collected (source has no span)
-    let _resolver = Resolver::new(&table);
-    let target = _resolver.resolve("Target").unwrap();
+    let resolver = Resolver::new(&table);
+    let target = resolver.resolve("Target").unwrap();
     assert_eq!(target.references().len(), 0);
 }
 
@@ -665,8 +665,8 @@ fn test_mixed_relationships() {
     collector.collect();
 
     // Verify Base has references from both relationships
-    let _resolver = Resolver::new(&table);
-    let base = _resolver.resolve("Base").unwrap();
+    let resolver = Resolver::new(&table);
+    let base = resolver.resolve("Base").unwrap();
     assert_eq!(base.references().len(), 2);
 
     let lines: Vec<_> = base

--- a/crates/syster-base/src/semantic/resolver/name_resolver.rs
+++ b/crates/syster-base/src/semantic/resolver/name_resolver.rs
@@ -95,10 +95,17 @@ impl<'a> Resolver<'a> {
     // Alias Resolution
     // ============================================================
 
-    fn resolve_alias(&self, symbol: &Symbol) -> Option<&Symbol> {
+    /// Resolve an alias to its target symbol.
+    /// For non-alias symbols, returns the symbol itself.
+    fn resolve_alias<'b>(&self, symbol: &'b Symbol) -> Option<&'b Symbol>
+    where
+        'a: 'b,
+    {
         match symbol {
-            Symbol::Alias { target, .. } => self.resolve(target),
-            _ => self.resolve_qualified(symbol.qualified_name()),
+            // For aliases, resolve the target by qualified name
+            Symbol::Alias { target, .. } => self.symbol_table.find_by_qualified_name(target),
+            // For non-aliases, return the symbol directly
+            _ => Some(symbol),
         }
     }
 }

--- a/crates/syster-base/src/semantic/symbol_table/tests/tests_lookup_from_scope.rs
+++ b/crates/syster-base/src/semantic/symbol_table/tests/tests_lookup_from_scope.rs
@@ -21,8 +21,8 @@ fn test_lookup_from_scope_in_current_scope() {
     table.insert("RootSymbol".to_string(), symbol).unwrap();
 
     // Lookup from scope 0 should find it
-    let _resolver = Resolver::new(&table);
-    let found = _resolver.resolve_in_scope("RootSymbol", 0);
+    let resolver = Resolver::new(&table);
+    let found = resolver.resolve_in_scope("RootSymbol", 0);
     assert!(found.is_some());
     assert_eq!(found.unwrap().name(), "RootSymbol");
 }
@@ -50,8 +50,8 @@ fn test_lookup_from_scope_in_parent_scope() {
     let child_scope = table.enter_scope();
 
     // Lookup from child scope should find symbol in parent
-    let _resolver = Resolver::new(&table);
-    let found = _resolver.resolve_in_scope("ParentSymbol", child_scope);
+    let resolver = Resolver::new(&table);
+    let found = resolver.resolve_in_scope("ParentSymbol", child_scope);
     assert!(found.is_some());
     assert_eq!(found.unwrap().name(), "ParentSymbol");
 }
@@ -82,8 +82,8 @@ fn test_lookup_from_scope_in_grandparent_scope() {
     let grandchild_scope = table.enter_scope();
 
     // Lookup from grandchild should find symbol in grandparent
-    let _resolver = Resolver::new(&table);
-    let found = _resolver.resolve_in_scope("GrandparentSymbol", grandchild_scope);
+    let resolver = Resolver::new(&table);
+    let found = resolver.resolve_in_scope("GrandparentSymbol", grandchild_scope);
     assert!(found.is_some());
     assert_eq!(found.unwrap().name(), "GrandparentSymbol");
 }
@@ -106,8 +106,8 @@ fn test_lookup_from_scope_not_found() {
     table.insert("ExistingSymbol".to_string(), symbol).unwrap();
 
     // Try to find a non-existent symbol from root scope
-    let _resolver = Resolver::new(&table);
-    let found = _resolver.resolve_in_scope("NonExistentSymbol", 0);
+    let resolver = Resolver::new(&table);
+    let found = resolver.resolve_in_scope("NonExistentSymbol", 0);
     assert!(found.is_none());
 }
 
@@ -146,8 +146,8 @@ fn test_lookup_from_scope_symbol_shadowing() {
     table.insert("Symbol".to_string(), child_symbol).unwrap();
 
     // Lookup from child scope should find the child scope symbol (shadowing)
-    let _resolver = Resolver::new(&table);
-    let found = _resolver.resolve_in_scope("Symbol", child_scope);
+    let resolver = Resolver::new(&table);
+    let found = resolver.resolve_in_scope("Symbol", child_scope);
     assert!(found.is_some());
     let symbol = found.unwrap();
     assert_eq!(symbol.qualified_name(), "Parent::Child::Symbol");
@@ -175,8 +175,8 @@ fn test_lookup_from_scope_from_root() {
     table.enter_scope();
 
     // Lookup from root scope should only find root symbol, not check children
-    let _resolver = Resolver::new(&table);
-    let found = _resolver.resolve_in_scope("RootSymbol", 0);
+    let resolver = Resolver::new(&table);
+    let found = resolver.resolve_in_scope("RootSymbol", 0);
     assert!(found.is_some());
 }
 
@@ -268,18 +268,18 @@ fn test_lookup_from_scope_different_symbol_types() {
         .unwrap();
 
     // From feature scope, should find all three up the chain
-    let _resolver = Resolver::new(&table);
-    let pkg = _resolver.resolve_in_scope("RootPkg", feature_scope);
+    let resolver = Resolver::new(&table);
+    let pkg = resolver.resolve_in_scope("RootPkg", feature_scope);
     assert!(pkg.is_some());
     assert!(matches!(pkg.unwrap(), Symbol::Package { .. }));
 
-    let _resolver = Resolver::new(&table);
-    let class = _resolver.resolve_in_scope("MyClass", feature_scope);
+    let resolver = Resolver::new(&table);
+    let class = resolver.resolve_in_scope("MyClass", feature_scope);
     assert!(class.is_some());
     assert!(matches!(class.unwrap(), Symbol::Classifier { .. }));
 
-    let _resolver = Resolver::new(&table);
-    let feature = _resolver.resolve_in_scope("MyFeature", feature_scope);
+    let resolver = Resolver::new(&table);
+    let feature = resolver.resolve_in_scope("MyFeature", feature_scope);
     assert!(feature.is_some());
     assert!(matches!(feature.unwrap(), Symbol::Feature { .. }));
 }
@@ -450,14 +450,14 @@ fn test_lookup_from_scope_with_alias() {
         .unwrap();
 
     // lookup_from_scope should find the alias (doesn't resolve it)
-    let _resolver = Resolver::new(&table);
-    let found = _resolver.resolve_in_scope("AliasSymbol", child_scope);
+    let resolver = Resolver::new(&table);
+    let found = resolver.resolve_in_scope("AliasSymbol", child_scope);
     assert!(found.is_some());
     assert!(matches!(found.unwrap(), Symbol::Alias { .. }));
 
     // Should also find the real symbol from child scope
-    let _resolver = Resolver::new(&table);
-    let real = _resolver.resolve_in_scope("RealSymbol", child_scope);
+    let resolver = Resolver::new(&table);
+    let real = resolver.resolve_in_scope("RealSymbol", child_scope);
     assert!(real.is_some());
     assert!(matches!(real.unwrap(), Symbol::Package { .. }));
 }
@@ -539,12 +539,12 @@ fn test_lookup_from_scope_idempotent() {
     table.insert("Symbol".to_string(), symbol).unwrap();
 
     // Multiple lookups should return the same result
-    let _resolver = Resolver::new(&table);
-    let found1 = _resolver.resolve_in_scope("Symbol", 0);
-    let _resolver = Resolver::new(&table);
-    let found2 = _resolver.resolve_in_scope("Symbol", 0);
-    let _resolver = Resolver::new(&table);
-    let found3 = _resolver.resolve_in_scope("Symbol", 0);
+    let resolver = Resolver::new(&table);
+    let found1 = resolver.resolve_in_scope("Symbol", 0);
+    let resolver = Resolver::new(&table);
+    let found2 = resolver.resolve_in_scope("Symbol", 0);
+    let resolver = Resolver::new(&table);
+    let found3 = resolver.resolve_in_scope("Symbol", 0);
 
     assert!(found1.is_some());
     assert!(found2.is_some());

--- a/crates/syster-base/src/semantic/symbol_table/tests/tests_symbol_table.rs
+++ b/crates/syster-base/src/semantic/symbol_table/tests/tests_symbol_table.rs
@@ -24,8 +24,8 @@ fn test_insert_and_lookup() {
     table
         .insert("MyPackage".to_string(), symbol.clone())
         .unwrap();
-    let _resolver = Resolver::new(&table);
-    let found = _resolver.resolve("MyPackage");
+    let resolver = Resolver::new(&table);
+    let found = resolver.resolve("MyPackage");
     assert!(found.is_some());
     assert_eq!(found.unwrap(), &symbol);
 }

--- a/crates/syster-base/src/semantic/workspace/tests/tests_workspace.rs
+++ b/crates/syster-base/src/semantic/workspace/tests/tests_workspace.rs
@@ -48,8 +48,8 @@ fn test_populate_single_file() {
     assert!(result.is_ok(), "Failed to populate: {:?}", result.err());
 
     // Verify symbol was added to the shared symbol table
-    let _resolver = Resolver::new(workspace.symbol_table());
-    let symbol = _resolver.resolve("Vehicle");
+    let resolver = Resolver::new(workspace.symbol_table());
+    let symbol = resolver.resolve("Vehicle");
     assert!(symbol.is_some());
     assert_eq!(symbol.unwrap().source_file(), Some("vehicle.sysml"));
 }
@@ -81,13 +81,13 @@ fn test_populate_multiple_files() {
     assert!(result.is_ok(), "Failed to populate: {:?}", result.err());
 
     // Verify both symbols are in the shared symbol table
-    let _resolver = Resolver::new(workspace.symbol_table());
-    let vehicle = _resolver.resolve("Vehicle");
+    let resolver = Resolver::new(workspace.symbol_table());
+    let vehicle = resolver.resolve("Vehicle");
     assert!(vehicle.is_some());
     assert_eq!(vehicle.unwrap().source_file(), Some("vehicle.sysml"));
 
-    let _resolver = Resolver::new(workspace.symbol_table());
-    let car = _resolver.resolve("Car");
+    let resolver = Resolver::new(workspace.symbol_table());
+    let car = resolver.resolve("Car");
     assert!(car.is_some());
     assert_eq!(car.unwrap().source_file(), Some("car.sysml"));
 
@@ -114,8 +114,8 @@ fn test_update_file_content() {
     workspace.populate_file(&path).unwrap();
 
     // Verify initial content
-    let _resolver = Resolver::new(workspace.symbol_table());
-    let symbol = _resolver.resolve("Vehicle");
+    let resolver = Resolver::new(workspace.symbol_table());
+    let symbol = resolver.resolve("Vehicle");
     assert!(symbol.is_some());
 
     // Get initial version
@@ -1468,8 +1468,8 @@ fn test_symbol_table_mut_basic() {
         .unwrap();
 
     // Verify it was added
-    let _resolver = Resolver::new(workspace.symbol_table());
-    let lookup = _resolver.resolve("TestPackage");
+    let resolver = Resolver::new(workspace.symbol_table());
+    let lookup = resolver.resolve("TestPackage");
     assert!(lookup.is_some());
 }
 
@@ -1537,8 +1537,8 @@ fn test_symbol_table_mut_independent_from_immutable() {
         .unwrap();
 
     // Access via immutable reference
-    let _resolver = Resolver::new(workspace.symbol_table());
-    let symbol = _resolver.resolve("Test");
+    let resolver = Resolver::new(workspace.symbol_table());
+    let symbol = resolver.resolve("Test");
     assert!(symbol.is_some());
     assert_eq!(symbol.unwrap().name(), "Test");
 }

--- a/crates/syster-base/tests/semantic/tests_cross_file.rs
+++ b/crates/syster-base/tests/semantic/tests_cross_file.rs
@@ -168,16 +168,16 @@ fn test_cross_file_transitive_relationships() {
     );
 
     // Verify all symbols exist with correct source files
-    let _resolver = Resolver::new(&symbol_table);
-    let thing_symbol = _resolver.resolve("Thing").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let thing_symbol = resolver.resolve("Thing").unwrap();
     assert_eq!(thing_symbol.source_file(), Some("file1.sysml"));
 
-    let _resolver = Resolver::new(&symbol_table);
-    let vehicle_symbol = _resolver.resolve("Vehicle").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let vehicle_symbol = resolver.resolve("Vehicle").unwrap();
     assert_eq!(vehicle_symbol.source_file(), Some("file2.sysml"));
 
-    let _resolver = Resolver::new(&symbol_table);
-    let car_symbol = _resolver.resolve("Car").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let car_symbol = resolver.resolve("Car").unwrap();
     assert_eq!(car_symbol.source_file(), Some("file3.sysml"));
 
     // Verify transitive relationships across files
@@ -238,10 +238,10 @@ fn test_symbol_source_tracking() {
     populator2.populate(&file2).unwrap();
 
     // We can now query which file a symbol came from
-    let _resolver = Resolver::new(&symbol_table);
-    let vehicle_symbol = _resolver.resolve("Vehicle").unwrap();
-    let _resolver = Resolver::new(&symbol_table);
-    let car_symbol = _resolver.resolve("Car").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let vehicle_symbol = resolver.resolve("Vehicle").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let car_symbol = resolver.resolve("Car").unwrap();
 
     assert_eq!(vehicle_symbol.source_file(), Some("vehicle.sysml"));
     assert_eq!(car_symbol.source_file(), Some("car.sysml"));

--- a/crates/syster-base/tests/semantic/tests_import.rs
+++ b/crates/syster-base/tests/semantic/tests_import.rs
@@ -60,13 +60,13 @@ fn test_import_membership() {
     assert!(result.is_ok(), "Failed to populate: {:?}", result.err());
 
     // Vehicle should be accessible in Derived package due to import
-    let _resolver = Resolver::new(workspace.symbol_table());
-    let my_car = _resolver.resolve_qualified("Derived::myCar");
+    let resolver = Resolver::new(workspace.symbol_table());
+    let my_car = resolver.resolve_qualified("Derived::myCar");
     assert!(my_car.is_some(), "myCar should be defined");
 
     // Verify that Base::Vehicle can be found (the imported member)
-    let _resolver = Resolver::new(workspace.symbol_table());
-    let vehicle = _resolver.resolve_qualified("Base::Vehicle");
+    let resolver = Resolver::new(workspace.symbol_table());
+    let vehicle = resolver.resolve_qualified("Base::Vehicle");
     assert!(
         vehicle.is_some(),
         "Base::Vehicle should exist and be importable"
@@ -105,8 +105,8 @@ fn test_import_membership_with_namespace() {
     assert!(result.is_ok(), "Failed to populate: {:?}", result.err());
 
     // Member import: only Vehicle should be accessible in Derived1
-    let _resolver = Resolver::new(workspace.symbol_table());
-    let car1 = _resolver.resolve_qualified("Derived1::myCar");
+    let resolver = Resolver::new(workspace.symbol_table());
+    let car1 = resolver.resolve_qualified("Derived1::myCar");
     assert!(car1.is_some(), "Derived1::myCar should be defined");
 
     // Namespace import: both Vehicle and Engine should be accessible in Derived2
@@ -145,10 +145,10 @@ fn test_import_namespace() {
     assert!(result.is_ok(), "Failed to populate: {:?}", result.err());
 
     // Both Vehicle and Engine should be accessible via namespace import
-    let _resolver = Resolver::new(workspace.symbol_table());
-    let car = _resolver.resolve_qualified("Derived::car");
-    let _resolver = Resolver::new(workspace.symbol_table());
-    let engine = _resolver.resolve_qualified("Derived::engine");
+    let resolver = Resolver::new(workspace.symbol_table());
+    let car = resolver.resolve_qualified("Derived::car");
+    let resolver = Resolver::new(workspace.symbol_table());
+    let engine = resolver.resolve_qualified("Derived::engine");
 
     assert!(car.is_some(), "car should be defined");
     assert!(engine.is_some(), "engine should be defined");
@@ -188,8 +188,8 @@ fn test_cross_file_import() {
     assert!(result.is_ok(), "Failed to populate: {:?}", result.err());
 
     // Car should be able to specialize Vehicle from the imported package
-    let _resolver = Resolver::new(workspace.symbol_table());
-    let car = _resolver.resolve_qualified("Car");
+    let resolver = Resolver::new(workspace.symbol_table());
+    let car = resolver.resolve_qualified("Car");
     assert!(car.is_some(), "Car should be defined");
 }
 
@@ -221,8 +221,8 @@ fn test_import_visibility() {
     workspace.populate_all().expect("Population should succeed");
 
     // With model-level imports, both should work
-    let _resolver = Resolver::new(workspace.symbol_table());
-    let y = _resolver.resolve_qualified("B::y");
+    let resolver = Resolver::new(workspace.symbol_table());
+    let y = resolver.resolve_qualified("B::y");
     assert!(y.is_some(), "y should be defined in package B");
 }
 

--- a/crates/syster-base/tests/semantic/tests_kerml_visitor.rs
+++ b/crates/syster-base/tests/semantic/tests_kerml_visitor.rs
@@ -34,8 +34,8 @@ fn test_kerml_visitor_creates_classifier_symbol() {
     let mut adapter = KermlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let symbol = _resolver.resolve("Vehicle").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let symbol = resolver.resolve("Vehicle").unwrap();
     match symbol {
         Symbol::Classifier { kind, .. } => assert_eq!(kind, "Classifier"),
         _ => panic!("Expected Classifier symbol"),
@@ -53,8 +53,8 @@ fn test_kerml_visitor_creates_datatype_symbol() {
     let mut adapter = KermlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let symbol = _resolver.resolve("Temperature").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let symbol = resolver.resolve("Temperature").unwrap();
     match symbol {
         Symbol::Definition { kind, .. } => assert_eq!(kind, "Datatype"),
         _ => panic!("Expected Definition symbol"),
@@ -72,8 +72,8 @@ fn test_kerml_visitor_creates_feature_symbol() {
     let mut adapter = KermlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let symbol = _resolver.resolve("mass").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let symbol = resolver.resolve("mass").unwrap();
     match symbol {
         Symbol::Feature { .. } => (),
         _ => panic!("Expected Feature symbol"),
@@ -123,8 +123,8 @@ fn test_kerml_visitor_creates_function_symbol() {
     let mut adapter = KermlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let symbol = _resolver.resolve("calculateArea").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let symbol = resolver.resolve("calculateArea").unwrap();
     match symbol {
         Symbol::Definition { kind, .. } => assert_eq!(kind, "Function"),
         _ => panic!("Expected Function symbol"),
@@ -189,8 +189,8 @@ fn test_kerml_visitor_handles_abstract_classifiers() {
     let mut adapter = KermlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let symbol = _resolver.resolve("Shape").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let symbol = resolver.resolve("Shape").unwrap();
     match symbol {
         Symbol::Classifier {
             kind, is_abstract, ..
@@ -214,8 +214,8 @@ fn test_kerml_visitor_handles_readonly_features() {
     adapter.populate(&file).unwrap();
 
     // For now, just verify the symbol exists - readonly modifier tracking will be added later
-    let _resolver = Resolver::new(&symbol_table);
-    let symbol = _resolver.resolve("timestamp");
+    let resolver = Resolver::new(&symbol_table);
+    let symbol = resolver.resolve("timestamp");
     assert!(symbol.is_some(), "timestamp feature should exist");
 }
 

--- a/crates/syster-base/tests/semantic/tests_sysml_visitor.rs
+++ b/crates/syster-base/tests/semantic/tests_sysml_visitor.rs
@@ -35,8 +35,8 @@ fn test_visitor_creates_definition_symbol() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let symbol = _resolver.resolve("Vehicle").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let symbol = resolver.resolve("Vehicle").unwrap();
     match symbol {
         Symbol::Definition { kind, .. } => assert_eq!(kind, "Part"),
         _ => panic!("Expected Definition symbol"),
@@ -394,8 +394,8 @@ fn test_visitor_creates_usage_symbol() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let symbol = _resolver.resolve("myCar").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let symbol = resolver.resolve("myCar").unwrap();
     match symbol {
         Symbol::Usage { usage_type, .. } => {
             assert_eq!(usage_type.as_deref(), Some("Vehicle"));
@@ -576,22 +576,22 @@ fn test_different_definition_kinds() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let part_def = _resolver.resolve("PartDef").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let part_def = resolver.resolve("PartDef").unwrap();
     match part_def {
         Symbol::Definition { kind, .. } => assert_eq!(kind, "Part"),
         _ => panic!("Expected Definition symbol"),
     }
 
-    let _resolver = Resolver::new(&symbol_table);
-    let action_def = _resolver.resolve("ActionDef").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let action_def = resolver.resolve("ActionDef").unwrap();
     match action_def {
         Symbol::Definition { kind, .. } => assert_eq!(kind, "Action"),
         _ => panic!("Expected Definition symbol"),
     }
 
-    let _resolver = Resolver::new(&symbol_table);
-    let req_def = _resolver.resolve("ReqDef").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let req_def = resolver.resolve("ReqDef").unwrap();
     match req_def {
         Symbol::Definition { kind, .. } => assert_eq!(kind, "Requirement"),
         _ => panic!("Expected Definition symbol"),
@@ -690,8 +690,8 @@ fn test_empty_definition() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let symbol = _resolver.resolve("EmptyPart").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let symbol = resolver.resolve("EmptyPart").unwrap();
     match symbol {
         Symbol::Definition { name, .. } => assert_eq!(name, "EmptyPart"),
         _ => panic!("Expected Definition symbol"),
@@ -709,8 +709,8 @@ fn test_usage_without_type() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let symbol = _resolver.resolve("untyped").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let symbol = resolver.resolve("untyped").unwrap();
     match symbol {
         Symbol::Usage { usage_type, .. } => {
             assert_eq!(
@@ -739,8 +739,8 @@ fn test_qualified_names_are_correct() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let vehicles = _resolver.resolve("Vehicles").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let vehicles = resolver.resolve("Vehicles").unwrap();
     match vehicles {
         Symbol::Package { qualified_name, .. } => {
             assert_eq!(qualified_name, "Vehicles");
@@ -885,8 +885,8 @@ fn test_port_definition_and_usage() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let port_def = _resolver.resolve("DataPort").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let port_def = resolver.resolve("DataPort").unwrap();
     match port_def {
         Symbol::Definition { kind, .. } => {
             assert_eq!(kind, "Port");
@@ -929,8 +929,8 @@ fn test_action_with_parameters() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let action_def = _resolver.resolve("ProcessData").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let action_def = resolver.resolve("ProcessData").unwrap();
     match action_def {
         Symbol::Definition { kind, .. } => {
             assert_eq!(kind, "Action");
@@ -962,8 +962,8 @@ fn test_constraint_definition() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let constraint_def = _resolver.resolve("SpeedLimit").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let constraint_def = resolver.resolve("SpeedLimit").unwrap();
     match constraint_def {
         Symbol::Definition { kind, .. } => {
             assert_eq!(kind, "Constraint");
@@ -989,8 +989,8 @@ fn test_enumeration_definition() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let enum_def = _resolver.resolve("Color").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let enum_def = resolver.resolve("Color").unwrap();
     match enum_def {
         Symbol::Definition { kind, .. } => {
             assert_eq!(kind, "Enumeration");
@@ -1026,8 +1026,8 @@ fn test_state_definition() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let state_def = _resolver.resolve("VehicleState").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let state_def = resolver.resolve("VehicleState").unwrap();
     match state_def {
         Symbol::Definition { kind, .. } => {
             assert_eq!(kind, "State");
@@ -1047,8 +1047,8 @@ fn test_connection_definition() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let conn_def = _resolver.resolve("DataFlow").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let conn_def = resolver.resolve("DataFlow").unwrap();
     match conn_def {
         Symbol::Definition { kind, .. } => {
             assert_eq!(kind, "Connection");
@@ -1068,8 +1068,8 @@ fn test_interface_definition() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let intf_def = _resolver.resolve("NetworkInterface").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let intf_def = resolver.resolve("NetworkInterface").unwrap();
     match intf_def {
         Symbol::Definition { kind, .. } => {
             assert_eq!(kind, "Interface");
@@ -1089,8 +1089,8 @@ fn test_allocation_definition() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let alloc_def = _resolver.resolve("ResourceAllocation").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let alloc_def = resolver.resolve("ResourceAllocation").unwrap();
     match alloc_def {
         Symbol::Definition { kind, .. } => {
             assert_eq!(kind, "Allocation");
@@ -1146,8 +1146,8 @@ fn test_concern_and_requirement() {
     let mut adapter = SysmlAdapter::with_relationships(&mut symbol_table, &mut graph);
     adapter.populate(&file).unwrap();
 
-    let _resolver = Resolver::new(&symbol_table);
-    let concern = _resolver.resolve("Safety").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let concern = resolver.resolve("Safety").unwrap();
     match concern {
         Symbol::Definition { kind, .. } => {
             assert_eq!(kind, "UseCase"); // Concern maps to UseCase
@@ -1155,8 +1155,8 @@ fn test_concern_and_requirement() {
         _ => panic!("Expected Definition symbol"),
     }
 
-    let _resolver = Resolver::new(&symbol_table);
-    let requirement = _resolver.resolve("SafetyRequirement").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let requirement = resolver.resolve("SafetyRequirement").unwrap();
     match requirement {
         Symbol::Definition { kind, .. } => {
             assert_eq!(kind, "Requirement");

--- a/crates/syster-base/tests/tests_semantic_cross_file.rs
+++ b/crates/syster-base/tests/tests_semantic_cross_file.rs
@@ -168,16 +168,16 @@ fn test_cross_file_transitive_relationships() {
     );
 
     // Verify all symbols exist with correct source files
-    let _resolver = Resolver::new(&symbol_table);
-    let thing_symbol = _resolver.resolve("Thing").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let thing_symbol = resolver.resolve("Thing").unwrap();
     assert_eq!(thing_symbol.source_file(), Some("file1.sysml"));
 
-    let _resolver = Resolver::new(&symbol_table);
-    let vehicle_symbol = _resolver.resolve("Vehicle").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let vehicle_symbol = resolver.resolve("Vehicle").unwrap();
     assert_eq!(vehicle_symbol.source_file(), Some("file2.sysml"));
 
-    let _resolver = Resolver::new(&symbol_table);
-    let car_symbol = _resolver.resolve("Car").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let car_symbol = resolver.resolve("Car").unwrap();
     assert_eq!(car_symbol.source_file(), Some("file3.sysml"));
 
     // Verify transitive relationships across files
@@ -238,10 +238,10 @@ fn test_symbol_source_tracking() {
     populator2.populate(&file2).unwrap();
 
     // We can now query which file a symbol came from
-    let _resolver = Resolver::new(&symbol_table);
-    let vehicle_symbol = _resolver.resolve("Vehicle").unwrap();
-    let _resolver = Resolver::new(&symbol_table);
-    let car_symbol = _resolver.resolve("Car").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let vehicle_symbol = resolver.resolve("Vehicle").unwrap();
+    let resolver = Resolver::new(&symbol_table);
+    let car_symbol = resolver.resolve("Car").unwrap();
 
     assert_eq!(vehicle_symbol.source_file(), Some("vehicle.sysml"));
     assert_eq!(car_symbol.source_file(), Some("car.sysml"));

--- a/crates/syster-base/tests/tests_semantic_import.rs
+++ b/crates/syster-base/tests/tests_semantic_import.rs
@@ -60,13 +60,13 @@ fn test_import_membership() {
     assert!(result.is_ok(), "Failed to populate: {:?}", result.err());
 
     // Vehicle should be accessible in Derived package due to import
-    let _resolver = Resolver::new(workspace.symbol_table());
-    let my_car = _resolver.resolve_qualified("Derived::myCar");
+    let resolver = Resolver::new(workspace.symbol_table());
+    let my_car = resolver.resolve_qualified("Derived::myCar");
     assert!(my_car.is_some(), "myCar should be defined");
 
     // Verify that Base::Vehicle can be found (the imported member)
-    let _resolver = Resolver::new(workspace.symbol_table());
-    let vehicle = _resolver.resolve_qualified("Base::Vehicle");
+    let resolver = Resolver::new(workspace.symbol_table());
+    let vehicle = resolver.resolve_qualified("Base::Vehicle");
     assert!(
         vehicle.is_some(),
         "Base::Vehicle should exist and be importable"
@@ -105,8 +105,8 @@ fn test_import_membership_with_namespace() {
     assert!(result.is_ok(), "Failed to populate: {:?}", result.err());
 
     // Member import: only Vehicle should be accessible in Derived1
-    let _resolver = Resolver::new(workspace.symbol_table());
-    let car1 = _resolver.resolve_qualified("Derived1::myCar");
+    let resolver = Resolver::new(workspace.symbol_table());
+    let car1 = resolver.resolve_qualified("Derived1::myCar");
     assert!(car1.is_some(), "Derived1::myCar should be defined");
 
     // Namespace import: both Vehicle and Engine should be accessible in Derived2
@@ -145,10 +145,10 @@ fn test_import_namespace() {
     assert!(result.is_ok(), "Failed to populate: {:?}", result.err());
 
     // Both Vehicle and Engine should be accessible via namespace import
-    let _resolver = Resolver::new(workspace.symbol_table());
-    let car = _resolver.resolve_qualified("Derived::car");
-    let _resolver = Resolver::new(workspace.symbol_table());
-    let engine = _resolver.resolve_qualified("Derived::engine");
+    let resolver = Resolver::new(workspace.symbol_table());
+    let car = resolver.resolve_qualified("Derived::car");
+    let resolver = Resolver::new(workspace.symbol_table());
+    let engine = resolver.resolve_qualified("Derived::engine");
 
     assert!(car.is_some(), "car should be defined");
     assert!(engine.is_some(), "engine should be defined");
@@ -188,8 +188,8 @@ fn test_cross_file_import() {
     assert!(result.is_ok(), "Failed to populate: {:?}", result.err());
 
     // Car should be able to specialize Vehicle from the imported package
-    let _resolver = Resolver::new(workspace.symbol_table());
-    let car = _resolver.resolve_qualified("Car");
+    let resolver = Resolver::new(workspace.symbol_table());
+    let car = resolver.resolve_qualified("Car");
     assert!(car.is_some(), "Car should be defined");
 }
 
@@ -221,8 +221,8 @@ fn test_import_visibility() {
     workspace.populate_all().expect("Population should succeed");
 
     // With model-level imports, both should work
-    let _resolver = Resolver::new(workspace.symbol_table());
-    let y = _resolver.resolve_qualified("B::y");
+    let resolver = Resolver::new(workspace.symbol_table());
+    let y = resolver.resolve_qualified("B::y");
     assert!(y.is_some(), "y should be defined in package B");
 }
 
@@ -285,8 +285,8 @@ fn test_import_alias() {
     assert!(result.is_ok(), "Failed to populate: {:?}", result.err());
 
     // Verify that Car can reference BaseVehicle (the alias)
-    let _resolver = Resolver::new(workspace.symbol_table());
-    let car = _resolver.resolve_qualified("Derived::Car");
+    let resolver = Resolver::new(workspace.symbol_table());
+    let car = resolver.resolve_qualified("Derived::Car");
     assert!(car.is_some(), "Car should be defined");
 
     // Verify that BaseVehicle resolves to Vehicle

--- a/crates/syster-base/tests/tests_semantic_resolver.rs
+++ b/crates/syster-base/tests/tests_semantic_resolver.rs
@@ -1107,8 +1107,8 @@ fn test_resolve_in_scope_qualified_name() {
     let scope_id = table.current_scope_id();
 
     // Should find by qualified name from any scope
-    let _resolver = Resolver::new(&table);
-    let result = _resolver.resolve_in_scope("Base::Vehicle", scope_id);
+    let resolver = Resolver::new(&table);
+    let result = resolver.resolve_in_scope("Base::Vehicle", scope_id);
     assert!(result.is_some());
     assert_eq!(result.unwrap().qualified_name(), "Base::Vehicle");
 }
@@ -1160,14 +1160,14 @@ fn test_resolve_in_scope_with_import() {
     let scope_without_import = table.current_scope_id();
 
     // From scope with import, should resolve "Vehicle" via import
-    let _resolver = Resolver::new(&table);
-    let result = _resolver.resolve_in_scope("Vehicle", scope_with_import);
+    let resolver = Resolver::new(&table);
+    let result = resolver.resolve_in_scope("Vehicle", scope_with_import);
     assert!(result.is_some(), "Should find Vehicle via import");
     assert_eq!(result.unwrap().qualified_name(), "Base::Vehicle");
 
     // From scope without import, should NOT find "Vehicle"
-    let _resolver = Resolver::new(&table);
-    let result = _resolver.resolve_in_scope("Vehicle", scope_without_import);
+    let resolver = Resolver::new(&table);
+    let result = resolver.resolve_in_scope("Vehicle", scope_without_import);
     assert!(result.is_none(), "Should not find Vehicle without import");
 }
 
@@ -1208,35 +1208,35 @@ fn test_resolve_in_scope_direct_symbol() {
         .unwrap();
 
     // From child scope, should find local symbol by simple name
-    let _resolver = Resolver::new(&table);
-    let result = _resolver.resolve_in_scope("LocalDef", child_scope);
+    let resolver = Resolver::new(&table);
+    let result = resolver.resolve_in_scope("LocalDef", child_scope);
     assert!(result.is_some(), "Should find LocalDef from child scope");
 
     // From child scope, should find parent symbol
-    let _resolver = Resolver::new(&table);
-    let result = _resolver.resolve_in_scope("GlobalPackage", child_scope);
+    let resolver = Resolver::new(&table);
+    let result = resolver.resolve_in_scope("GlobalPackage", child_scope);
     assert!(
         result.is_some(),
         "Should find GlobalPackage from child scope"
     );
 
     // From root scope (0), should find global
-    let _resolver = Resolver::new(&table);
-    let result = _resolver.resolve_in_scope("GlobalPackage", 0);
+    let resolver = Resolver::new(&table);
+    let result = resolver.resolve_in_scope("GlobalPackage", 0);
     assert!(result.is_some());
 
     // From root scope (0), should NOT find LocalDef by simple name
     // (it's not in scope 0's symbols, not imported, and lookup walks UP not DOWN)
-    let _resolver = Resolver::new(&table);
-    let result = _resolver.resolve_in_scope("LocalDef", 0);
+    let resolver = Resolver::new(&table);
+    let result = resolver.resolve_in_scope("LocalDef", 0);
     assert!(
         result.is_none(),
         "Should not find LocalDef by simple name from root"
     );
 
     // But SHOULD find it by qualified name from anywhere
-    let _resolver = Resolver::new(&table);
-    let result = _resolver.resolve_in_scope("GlobalPackage::LocalDef", 0);
+    let resolver = Resolver::new(&table);
+    let result = resolver.resolve_in_scope("GlobalPackage::LocalDef", 0);
     assert!(
         result.is_some(),
         "Should find by qualified name from any scope"

--- a/crates/syster-base/tests/tests_semantic_workspace.rs
+++ b/crates/syster-base/tests/tests_semantic_workspace.rs
@@ -48,8 +48,8 @@ fn test_populate_single_file() {
     assert!(result.is_ok(), "Failed to populate: {:?}", result.err());
 
     // Verify symbol was added to the shared symbol table
-    let _resolver = Resolver::new(workspace.symbol_table());
-    let symbol = _resolver.resolve("Vehicle");
+    let resolver = Resolver::new(workspace.symbol_table());
+    let symbol = resolver.resolve("Vehicle");
     assert!(symbol.is_some());
     assert_eq!(symbol.unwrap().source_file(), Some("vehicle.sysml"));
 }
@@ -81,13 +81,13 @@ fn test_populate_multiple_files() {
     assert!(result.is_ok(), "Failed to populate: {:?}", result.err());
 
     // Verify both symbols are in the shared symbol table
-    let _resolver = Resolver::new(workspace.symbol_table());
-    let vehicle = _resolver.resolve("Vehicle");
+    let resolver = Resolver::new(workspace.symbol_table());
+    let vehicle = resolver.resolve("Vehicle");
     assert!(vehicle.is_some());
     assert_eq!(vehicle.unwrap().source_file(), Some("vehicle.sysml"));
 
-    let _resolver = Resolver::new(workspace.symbol_table());
-    let car = _resolver.resolve("Car");
+    let resolver = Resolver::new(workspace.symbol_table());
+    let car = resolver.resolve("Car");
     assert!(car.is_some());
     assert_eq!(car.unwrap().source_file(), Some("car.sysml"));
 
@@ -114,8 +114,8 @@ fn test_update_file_content() {
     workspace.populate_file(&path).unwrap();
 
     // Verify initial content
-    let _resolver = Resolver::new(workspace.symbol_table());
-    let symbol = _resolver.resolve("Vehicle");
+    let resolver = Resolver::new(workspace.symbol_table());
+    let symbol = resolver.resolve("Vehicle");
     assert!(symbol.is_some());
 
     // Get initial version
@@ -1416,8 +1416,8 @@ fn test_symbol_table_mut_basic() {
         .unwrap();
 
     // Verify it was added
-    let _resolver = Resolver::new(workspace.symbol_table());
-    let lookup = _resolver.resolve("TestPackage");
+    let resolver = Resolver::new(workspace.symbol_table());
+    let lookup = resolver.resolve("TestPackage");
     assert!(lookup.is_some());
 }
 
@@ -1485,8 +1485,8 @@ fn test_symbol_table_mut_independent_from_immutable() {
         .unwrap();
 
     // Access via immutable reference
-    let _resolver = Resolver::new(workspace.symbol_table());
-    let symbol = _resolver.resolve("Test");
+    let resolver = Resolver::new(workspace.symbol_table());
+    let symbol = resolver.resolve("Test");
     assert!(symbol.is_some());
     assert_eq!(symbol.unwrap().name(), "Test");
 }

--- a/crates/syster-lsp/src/server/tests/tests_server.rs
+++ b/crates/syster-lsp/src/server/tests/tests_server.rs
@@ -2211,7 +2211,15 @@ fn test_dimension_one_unit_cross_file_resolution() {
     use syster::semantic::Workspace;
     use syster::syntax::parser::parse_content;
 
-    let stdlib_path = std::path::PathBuf::from("../../target/debug/sysml.library");
+    // Use current_exe to find stdlib in correct target folder (debug or release)
+    let stdlib_path = std::env::current_exe()
+        .ok()
+        .and_then(|exe| {
+            exe.parent()
+                .and_then(|deps| deps.parent())
+                .map(|target| target.join("sysml.library"))
+        })
+        .unwrap_or_else(|| std::path::PathBuf::from("../../target/debug/sysml.library"));
 
     let mut workspace = Workspace::new();
     let loader = StdLibLoader::with_path(stdlib_path);


### PR DESCRIPTION
The `test_dimension_one_unit_cross_file_resolution` test was hardcoded to look for stdlib in `target/debug/sysml.library`, causing it to fail when run in release mode.

Now uses `current_exe()` to find the correct target folder (debug or release).