### PR TITLE
fix: correct rust-toolchain action name in vscode-extension workflow

### DIFF
--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Install Rust
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
       


### PR DESCRIPTION
The workflow was using `dtolnay/rust-action` which doesn't exist. Changed to the correct `dtolnay/rust-toolchain` action.

This fixes the v1.0.0-alpha release build failure.