### PR TITLE
fix: include server/ and sysml.library/ in VSIX package

### DIFF
--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -120,7 +120,7 @@ jobs:
       
       - name: Package extension
         working-directory: editors/vscode
-        run: npx vsce package --target ${{ matrix.vsce-target }} -o sysml-language-support-${{ matrix.platform }}.vsix
+        run: npx vsce package --no-gitignore --target ${{ matrix.vsce-target }} -o sysml-language-support-${{ matrix.platform }}.vsix
       
       - name: Upload VSIX
         uses: actions/upload-artifact@v4
@@ -178,7 +178,7 @@ jobs:
       
       - name: Package universal extension
         working-directory: editors/vscode
-        run: npx vsce package -o sysml-language-support-universal.vsix
+        run: npx vsce package --no-gitignore -o sysml-language-support-universal.vsix
       
       - name: Upload universal VSIX
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Add --no-gitignore flag to vsce package commands so that the server/ (LSP binaries) and sysml.library/ (stdlib) directories are included in the packaged extension.