### PR TITLE
chore(vscode): bump extension version to 0.1.2-alpha

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -2,7 +2,25 @@
 
 All notable changes to the "SysML v2 Language Support" extension will be documented in this file.
 
-## [0.1.0] - 2024-12-17
+## [0.1.2-alpha] - 2026-01-08
+
+### Fixed
+- Fixed previous release date in changelog
+
+## [0.1.1-alpha] - 2026-01-08
+
+### Changed
+- LSP server binary is now bundled with the extension (no separate installation required)
+- SysML v2 standard library is now bundled with the extension
+- Updated README to reflect bundled installation
+
+### Improved
+- LSP performance optimizations
+
+### Fixed
+- Simplified setup process - extension works out of the box
+
+## [0.1.0-alpha] - 2026-01-06
 
 ### Added
 - Initial release

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "sysml-language-support",
   "displayName": "SysML v2 Language Support",
   "description": "Language support for SysML v2 and KerML with LSP-based features",
-  "version": "0.1.1-alpha",
+  "version": "0.1.2-alpha",
   "publisher": "jade-codes",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Add 0.1.1-alpha to changelog (bundled LSP, stdlib, perf improvements)
- Fix previous release date