### PR TITLE
chore: revert extension name from syster to sysml-language-support

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "syster",
+  "name": "sysml-language-support",
   "displayName": "SysML v2 Language Support",
   "description": "Language support for SysML v2 and KerML with LSP-based features",
   "version": "0.1.7-alpha",


### PR DESCRIPTION
This pull request makes a small change to the VS Code extension's package configuration by updating the extension's name to better reflect its purpose. No other significant changes are included.

- Changed the `name` field in `package.json` from `syster` to `sysml-language-support` to clarify the extension's focus on SysML v2 language support.## Description

